### PR TITLE
merge: resolve teachers data loading issue

### DIFF
--- a/collegems-client/src/pages/HODDashboard.tsx
+++ b/collegems-client/src/pages/HODDashboard.tsx
@@ -25,6 +25,7 @@ import api from "../api/axios";
 import Students from "../common-components-management/Students";
 import HODSalary from "../hod-components/Salary";
 import HODTeacherAttendance from "../hod-components/TeacherAttendance";
+import Teachers from "../hod-components/Teachers";
 
 type TabType =
   | "overview"
@@ -413,6 +414,7 @@ export default function HODDashboard() {
             </div>
           )}
 
+          {activeTab === "teachers" && <Teachers />}
           {activeTab === "teachers-attendance" && <HODTeacherAttendance />}
           {activeTab === "students" && <Students />}
           {activeTab === "salary" && <HODSalary />}

--- a/collegems-server/package.json
+++ b/collegems-server/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
+    "dev": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Description

Fixes a dashboard rendering issue in the HOD Dashboard. The "Teachers" tab was defined in the sidebar navigation items, the `<Teachers />` component was never imported or rendered inside the main content area of `HODDashboard.tsx`. 

## Type of Change

- Imports the `<Teachers />` component at the top of `HODDashboard.tsx`.
- Adds the conditional rendering logic `{activeTab === "teachers" && <Teachers />}` inside the main dashboard viewport,                       resolving the blank page issue when switching to the Teachers tab.


