### PR TITLE
Add demo seed data for student teacher and hod roles

### DIFF
--- a/collegems-server/package.json
+++ b/collegems-server/package.json
@@ -4,10 +4,11 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "start": "node server.js",
+  "dev": "nodemon server.js",
+  "seed": "node src/seedDemoData.js",
+  "test": "echo \"Error: no test specified\" && exit 1"
+},
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/collegems-server/src/seedDemoData.js
+++ b/collegems-server/src/seedDemoData.js
@@ -1,0 +1,65 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+import mongoose from "mongoose";
+import bcrypt from "bcryptjs";
+
+import User from "./models/User.model.js";
+
+const seedData = async () => {
+  try {
+    await mongoose.connect(process.env.MONGO_URI);
+
+    console.log("MongoDB Connected");
+
+    // remove old demo users if they exist
+    await User.deleteMany({
+      email: {
+        $in: [
+          "student@example.com",
+          "teacher@example.com",
+          "hod@college.edu",
+        ],
+      },
+    });
+
+    const hashedPassword = await bcrypt.hash("password123", 10);
+
+    await User.create([
+      {
+        name: "Demo Student",
+        email: "student@example.com",
+        password: hashedPassword,
+        role: "student",
+        studentId: "STU001",
+        semester: "6",
+        course: "Computer Science",
+      },
+      {
+        name: "Demo Teacher",
+        email: "teacher@example.com",
+        password: hashedPassword,
+        role: "teacher",
+        teacherId: "TCH001",
+        department: "Computer Science",
+      },
+      {
+        name: "Demo HOD",
+        email: "hod@college.edu",
+        password: hashedPassword,
+        role: "hod",
+        departmentCode: "CSE",
+      },
+    ]);
+
+    console.log("Demo users created successfully");
+
+    process.exit();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+};
+
+seedData();


### PR DESCRIPTION
Fixes #7

## Description

Adds a seed script to populate the database with demo accounts for testing and demonstration purposes.

### Changes Made

* Added `src/seedDemoData.js`
* Created demo Student account
* Created demo Teacher account
* Created demo HOD account
* Added `npm run seed` script to `package.json`

These demo accounts help provide sample data for testing and verifying role-based functionality within the application.

## Type of Change

* [x] New feature

## Checklist

* [x] Code follows project style
* [ ] Tested locally
* [ ] Updated documentation