### PR TITLE
fix: add missing Library import in App.tsx

### DIFF
--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -14,6 +14,7 @@ import StudentResults from "./user-components/StudentResults";
 import EventsStudent from "./user-components/EventsStudent";
 import QuickAccessAll from "./pages/QuickAccessAll";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
+import Library from "./common-components-management/Library";
 export default function App() {
   return (
     <BrowserRouter>


### PR DESCRIPTION
## Description

This PR fixes a frontend runtime error caused by a missing import in `App.tsx`.

While setting up the project locally, the application displayed a blank page and failed to load due to the following error:

`ReferenceError: Library is not defined`

The `/library` route was using the `Library` component without importing it.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactoring

## Changes Made

* Added the missing `Library` component import in `collegems-client/src/App.tsx`.

## Testing

* Verified that the frontend loads successfully.
* Confirmed that the `/library` route works as expected.
* Tested the application locally after the fix.

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [ ] Updated documentation (not required for this fix)
