### PR TITLE
CORS ALLOWS ALL ORIGINS

### DIFF
--- a/collegems-server/src/app.js
+++ b/collegems-server/src/app.js
@@ -25,7 +25,12 @@ import academicCalendarRoutes from "./routes/academicCalendar.routes.js";
 const app = express();
 
 // Middlewares
-app.use(cors());
+app.use(cors({
+  origin: process.env.ALLOWED_ORIGINS?.split(",") || ["http://localhost:5173"],
+  credentials: true,
+  methods: ["GET", "POST", "PUT", "DELETE", "PATCH"],
+  allowedHeaders: ["Content-Type", "Authorization"]
+}));
 app.use(express.json());
 app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
 


### PR DESCRIPTION
## Description
This PR resolves a critical security vulnerability by restricting the Cross-Origin Resource Sharing (CORS) policy.

Replaced the unrestricted cors() middleware in src/app.js with a strictly defined configuration.

Restricted allowed origins to whitelisted domains using the ALLOWED_ORIGINS environment variable (falling back to http://localhost:5173 for local development).

Explicitly defined allowed HTTP methods (GET, POST, PUT, DELETE, PATCH) and headers (Content-Type, Authorization).

Enabled credentials: true to ensure secure, cookie-based authentication (like the new refresh tokens) works correctly across the frontend and backend.

Fixes issue #63.

## Type of Change

[x] Bug fix

[ ] New feature

[ ] Documentation update

[ ] Refactoring

## Checklist

[x] Code follows project style

[x] Tested locally

[x] Updated documentation (Added ALLOWED_ORIGINS to .env.example)