### PR TITLE
Plaintext Password Fallback in Authentication

### DIFF
--- a/collegems-server/src/controllers/auth.controller.js
+++ b/collegems-server/src/controllers/auth.controller.js
@@ -9,16 +9,9 @@ const normalizeEmail = (email) => email?.trim().toLowerCase();
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-const isBcryptHash = (password) =>
-  typeof password === "string" && BCRYPT_HASH_PATTERN.test(password);
-
 const verifyPassword = async (plainPassword, storedPassword) => {
   if (typeof storedPassword !== "string" || !storedPassword) {
     return false;
-  }
-
-  if (!isBcryptHash(storedPassword)) {
-    return plainPassword === storedPassword;
   }
 
   return bcrypt.compare(plainPassword, storedPassword);


### PR DESCRIPTION

## Description
This PR resolves a severe security vulnerability by removing a fallback mechanism that allowed plaintext password comparisons during authentication, ensuring strict adherence to cryptographic hashing standards.

Removed the !isBcryptHash fallback block in src/controllers/auth.controller.js.

Enforced that all login attempts strictly use bcrypt.compare() for password verification.

Ensured that legacy or manually inserted plaintext passwords in the database will safely fail authentication with a standard 401 Unauthorized response.

Fixes issue #59.

## Type of Change

[x] Bug fix

[ ] New feature

[ ] Documentation update

[x] Refactoring

## Checklist

[x] Code follows project style

[x] Tested locally

[ ] Updated documentation