### PR TITLE
Add auto-labeler for issues and update PR labeler

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,6 +13,6 @@ jobs:
 
     steps:
       - name: Auto assign PR author
-        uses: toshimaru/auto-author-assign@v2
+        uses: toshimaru/auto-author-assign@v2.1.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
   auto-assign:

--- a/.github/workflows/issue-auto-labeler.yml
+++ b/.github/workflows/issue-auto-labeler.yml
@@ -1,0 +1,46 @@
+name: Auto Label Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Parse Content and Apply Labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueTitle = context.payload.issue.title.toLowerCase();
+            const issueBody = (context.payload.issue.body || '').toLowerCase();
+
+            // 1. Add the default label requested by the maintainer
+            const labelsToAdd = ['Easy']; 
+
+            // 2. Define keywords based on the project's tech stack
+            const frontendKeywords = ['frontend', 'front-end', 'react', 'ui', 'client', 'css', 'vite'];
+            const backendKeywords = ['backend', 'back-end', 'node', 'server', 'api', 'database', 'mongo', 'express'];
+
+            // Helper function to check for keywords
+            const containsKeyword = (text, keywords) => keywords.some(kw => text.includes(kw));
+
+            // 3. Check title and body for matches
+            const isFrontend = containsKeyword(issueTitle, frontendKeywords) || containsKeyword(issueBody, frontendKeywords);
+            const isBackend = containsKeyword(issueTitle, backendKeywords) || containsKeyword(issueBody, backendKeywords);
+
+            if (isFrontend) labelsToAdd.push('frontend');
+            if (isBackend) labelsToAdd.push('backend');
+
+            // Note: 'bug' and 'enhancement' are already applied by the issue templates natively!
+
+            // 4. Apply the computed labels
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: labelsToAdd
+            });

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,8 +3,6 @@ name: Auto Label Pull Requests
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-  issues:
-    types: [opened, edited]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description

This PR introduces an auto-labeler workflow specifically for issues, fulfilling the request outlined in #98 for SSOC 2026.

**Key Changes:**
* **Added `issue-auto-labeler.yml`:** Created a dedicated GitHub Action using `github-script` that triggers on newly opened issues.
* **Default Label:** Automatically applies the `Easy` label to all new issues as requested by the repository owner.
* **Smart Domain Labeling:** The script scans the issue title and body for MERN stack keywords (e.g., react, node, ui, api) and dynamically applies `frontend` or `backend` labels alongside the default.
* **Fixed Existing Labeler:** Removed the invalid `issues` trigger from the existing `.github/workflows/labeler.yml`, since the official `actions/labeler` plugin only checks file diffs (which issues do not possess). 

Closes #98

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactoring

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation