### PR TITLE
feat(events): add read/unread tracking for events

### DIFF
--- a/collegems-server/src/controllers/events.controller.js
+++ b/collegems-server/src/controllers/events.controller.js
@@ -1,4 +1,6 @@
 import Event from "../models/Events.model.js";
+import User from "../models/User.model.js";
+
 
 // CREATE
 export const createEvent = async (req, res) => {
@@ -84,5 +86,151 @@ export const deleteEvent = async (req, res) => {
         });
     } catch (error) {
         res.status(500).json({ success: false, message: error.message });
+    }
+    
+};
+
+export const markEventAsRead = async (req, res) => {
+    try {
+        const event = await Event.findById(req.params.id);
+
+        if (!event) {
+            return res.status(404).json({
+                success: false,
+                message: "Event not found",
+            });
+        }
+
+        const userId = req.user.id;
+
+        if (!event.readBy.some(id => id.toString() === userId)) {
+            event.readBy.push(userId);
+            await event.save();
+        }
+
+        res.status(200).json({
+            success: true,
+            message: "Event marked as read",
+            data: event,
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message,
+        });
+    }
+};
+
+export const markEventAsUnread = async (req, res) => {
+    try {
+        const event = await Event.findById(req.params.id);
+
+        if (!event) {
+            return res.status(404).json({
+                success: false,
+                message: "Event not found",
+            });
+        }
+
+        const userId = req.user.id;
+
+        event.readBy = event.readBy.filter(
+            id => id.toString() !== userId
+        );
+
+        await event.save();
+
+        res.status(200).json({
+            success: true,
+            message: "Event marked as unread",
+            data: event,
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message,
+        });
+    }
+};
+
+export const getReadCount = async (req, res) => {
+    try {
+        const event = await Event.findById(req.params.id);
+
+        if (!event) {
+            return res.status(404).json({
+                success: false,
+                message: "Event not found",
+            });
+        }
+
+        res.status(200).json({
+            success: true,
+            readCount: event.readBy.length,
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message,
+        });
+    }
+};
+export const getReaders = async (req, res) => {
+    try {
+        const event = await Event.findById(req.params.id)
+            .populate("readBy", "name email studentId");
+
+        if (!event) {
+            return res.status(404).json({
+                success: false,
+                message: "Event not found",
+            });
+        }
+
+        res.status(200).json({
+            success: true,
+            count: event.readBy.length,
+            data: event.readBy,
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message,
+        });
+    }
+};
+
+export const getUnreadStudents = async (req, res) => {
+    try {
+        const event = await Event.findById(req.params.id);
+
+        if (!event) {
+            return res.status(404).json({
+                success: false,
+                message: "Event not found",
+            });
+        }
+
+        const students = await User.find({
+            role: "student",
+        });
+
+        const unreadStudents = students.filter(
+            student =>
+                !event.readBy.some(
+                    id => id.toString() === student._id.toString()
+                )
+        );
+
+        res.status(200).json({
+            success: true,
+            count: unreadStudents.length,
+            data: unreadStudents,
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message,
+        });
     }
 };

--- a/collegems-server/src/models/Events.model.js
+++ b/collegems-server/src/models/Events.model.js
@@ -7,6 +7,12 @@ const EventsSchema = new mongoose.Schema(
             required: true,
             trim: true,
         },
+        readBy: [
+  {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+  },
+],
 
         shortDescription: {
             type: String,

--- a/collegems-server/src/routes/event.routes.js
+++ b/collegems-server/src/routes/event.routes.js
@@ -1,17 +1,41 @@
-import express from "express";
 import {
     createEvent,
     getAllEvents,
     getEventById,
     updateEvent,
     deleteEvent,
+    markEventAsRead,
+    markEventAsUnread,
+    getReadCount,
+    getReaders,
+    getUnreadStudents,
 } from "../controllers/events.controller.js";
 import { protect } from "../middlewares/auth.middleware.js";
 import { allowRoles } from "../middlewares/role.middleware.js";
+import express from "express";
 
 
 const router = express.Router();
+router.get(
+    "/:id/read-count",
+    protect,
+    allowRoles("hod", "teacher"),
+    getReadCount
+);
 
+router.get(
+    "/:id/readers",
+    protect,
+    allowRoles("hod", "teacher"),
+    getReaders
+);
+
+router.get(
+    "/:id/unreaders",
+    protect,
+    allowRoles("hod", "teacher"),
+    getUnreadStudents
+);
 // PUBLIC ROUTES
 router.get("/", getAllEvents);
 router.get("/:id", getEventById);
@@ -20,5 +44,6 @@ router.get("/:id", getEventById);
 router.post("/create", protect, allowRoles('hod', 'teacher'), createEvent);
 router.put("/:id", protect, allowRoles('hod', 'teacher'), updateEvent);
 router.delete("/:id", protect, allowRoles('hod', 'teacher'), deleteEvent);
-
+router.post("/:id/read", protect, markEventAsRead);
+router.post("/:id/unread", protect, markEventAsUnread);
 export default router;


### PR DESCRIPTION
## Description

Implemented read/unread tracking for events.

### Changes made

* Added `readBy` field to the Event schema to store users who have viewed an event.
* Added API to mark an event as read.
* Added API to mark an event as unread.
* Added API to get the total number of users who have read an event.
* Added API to retrieve the list of users who have read an event.
* Added API to retrieve the list of students who have not read an event.
* Added corresponding routes for all read-tracking operations.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactoring

## Checklist

* [x] Code follows project style
* [ ] Tested locally
* [ ] Updated documentation
