### PR TITLE
feat: add club event linking and dashboard stability improvements

### DIFF
--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -11,7 +11,7 @@ import HodDashboard from "./pages/HODDashboard";
 import MainDashboard from "./pages/MainDashboard";
 import ParentDashboard from "./pages/ParentDashboard";
 import DashboardLayout from "./layouts/DashboardLayout";
-
+import Clubs from "./common-components-management/Clubs";
 import ExamSchedule from "./user-components/ExamSchedule";
 import Courses from "./user-components/Courses";
 import Teachers from "./hod-components/Teachers";
@@ -62,6 +62,7 @@ export default function App() {
             </ProtectedRoute>
           }
         />
+        <Route path="/clubs" element={<Clubs />} />
         <Route
           path="/events"
           element={

--- a/collegems-client/src/common-components-management/ClubManagement.tsx
+++ b/collegems-client/src/common-components-management/ClubManagement.tsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useState } from "react";
+import {
+  ArrowLeft, Users, Calendar, UserCheck, UserX, Crown, Shield,
+  Trash2, X, AlertTriangle, CheckCircle, ChevronDown, Link2, Unlink,
+  Megaphone, Send, Clock
+} from "lucide-react";
+import api from "../api/axios";
+
+interface MemberUser { _id: string; name: string; email: string; role: string; }
+interface Member { user: MemberUser; role: string; joinedAt: string; }
+interface ClubEvent { _id: string; title: string; date: string; status: string; category: string; }
+interface PendingRequest { user: MemberUser; message?: string; requestedAt: string; }
+interface Announcement { _id: string; message: string; postedBy: MemberUser; date: string; }
+interface Club {
+  _id: string; name: string; description: string; category: string; createdBy: MemberUser;
+  admins: MemberUser[]; members: Member[]; pendingRequests: PendingRequest[]; events: ClubEvent[];
+  announcements?: Announcement[]; maxMembers: number; isActive: boolean;
+}
+interface AllEvent { _id: string; title: string; date: string; }
+const ROLES = ["member", "coordinator", "secretary", "treasurer", "vice-president", "president"];
+
+interface Props { club: Club; onBack: () => void; onUpdated: (club: Club) => void; showToast: (type: "success" | "error", msg: string) => void; }
+
+const ClubManagement: React.FC<Props> = ({ club, onBack, onUpdated, showToast }) => {
+  // THE FIX: Fetch fresh ID inside component
+  const getSafeUserId = () => {
+    try {
+      const data = JSON.parse(localStorage.getItem("userData") || "{}");
+      const id = data._id || data.id || data.userId || (data.user && (data.user._id || data.user.id));
+      return id ? String(id) : "MISSING_ID";
+    } catch { return "MISSING_ID"; }
+  };
+  const currentUserId = getSafeUserId();
+
+  const [activeTab, setActiveTab] = useState<"members" | "requests" | "events" | "announcements">("members");
+  const [allEvents, setAllEvents] = useState<AllEvent[]>([]);
+  const [selectedEvent, setSelectedEvent] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [announcementText, setAnnouncementText] = useState("");
+  const [posting, setPosting] = useState(false);
+
+  // ─── DYNAMIC IDENTIFICATION ───
+  const isMe = (entity: any) => {
+    if (!entity || currentUserId === "MISSING_ID") return false;
+    const id = typeof entity === "object" ? (entity._id || entity.id) : entity;
+    return String(id) === currentUserId;
+  };
+  
+  const isFounder = isMe(club.createdBy);
+  const isAdmin = isFounder || club.admins.some(isMe);
+  const iAmPresident = isFounder || club.members.find(m => isMe(m.user))?.role === "president";
+  const canKick = isFounder || iAmPresident;
+
+  useEffect(() => {
+    if (activeTab === "events" && isAdmin) {
+      api.get("/events")
+        .then((res) => {
+          console.log("SERVER RESPONSE FOR EVENTS:", res.data); // <-- This will show us the truth
+          
+          // This aggressively hunts for the array no matter how your backend formats it
+          const fetchedEvents = Array.isArray(res.data) ? res.data 
+                              : res.data?.events ? res.data.events 
+                              : res.data?.data ? res.data.data 
+                              : [];
+                              
+          setAllEvents(fetchedEvents);
+        })
+        .catch((err) => {
+          console.error("FAILED TO FETCH EVENTS:", err);
+        });
+    }
+  }, [activeTab, isAdmin]);
+
+  const refetch = async () => { try { const res = await api.get(`/clubs/${club._id}`); onUpdated(res.data); } catch { showToast("error", "Failed to refresh club data"); } };
+
+  const handleApprove = async (userId: string) => { try { await api.post(`/clubs/${club._id}/requests/${userId}/approve`); showToast("success", "Member approved"); refetch(); } catch (err: any) { showToast("error", err?.response?.data?.message || "Failed to approve"); } };
+  const handleReject = async (userId: string) => { try { await api.post(`/clubs/${club._id}/requests/${userId}/reject`); showToast("success", "Request rejected"); refetch(); } catch (err: any) { showToast("error", err?.response?.data?.message || "Failed to reject"); } };
+  const handleRemoveMember = async (userId: string) => { try { await api.delete(`/clubs/${club._id}/members/${userId}`); showToast("success", "Member removed"); refetch(); } catch (err: any) { showToast("error", err?.response?.data?.message || "Failed to remove member"); } };
+  const handleRoleChange = async (userId: string, role: string) => { try { await api.put(`/clubs/${club._id}/members/${userId}/role`, { role }); showToast("success", "Role updated"); refetch(); } catch (err: any) { showToast("error", err?.response?.data?.message || "Failed to update role"); } };
+  const handleToggleAdmin = async (userId: string, makeAdmin: boolean) => { try { await api.put(`/clubs/${club._id}/members/${userId}/role`, { makeAdmin }); showToast("success", "Admin status updated"); refetch(); } catch (err: any) { showToast("error", err?.response?.data?.message || "Failed to update status"); } };
+  const handleLinkEvent = async () => { if (!selectedEvent) return; try { await api.post(`/clubs/${club._id}/events`, { eventId: selectedEvent }); showToast("success", "Event linked"); setSelectedEvent(""); refetch(); } catch (err: any) { showToast("error", err?.response?.data?.message || "Failed to link event"); } };
+  const handleUnlinkEvent = async (eventId: string) => { try { await api.delete(`/clubs/${club._id}/events/${eventId}`); showToast("success", "Event unlinked"); refetch(); } catch (err: any) { showToast("error", err?.response?.data?.message || "Failed to unlink"); } };
+  const handlePostAnnouncement = async () => { if (!announcementText.trim()) return; setPosting(true); try { await api.post(`/clubs/${club._id}/announcements`, { message: announcementText }); showToast("success", "Posted!"); setAnnouncementText(""); refetch(); } catch (err: any) { showToast("error", "Failed to post"); } finally { setPosting(false); } };
+  const handleDeleteAnnouncement = async (announcementId: string) => { try { await api.delete(`/clubs/${club._id}/announcements/${announcementId}`); showToast("success", "Deleted"); refetch(); } catch (err: any) { showToast("error", "Failed to delete"); } };
+  const handleDeleteClub = async () => { try { await api.delete(`/clubs/${club._id}`); showToast("success", "Club deleted"); setConfirmDelete(false); onBack(); } catch (err: any) { showToast("error", err?.response?.data?.message || "Failed to delete"); setConfirmDelete(false); } };
+
+  const linkableEvents = allEvents.filter((e) => !club.events.some((ce) => ce._id === e._id));
+
+  return (
+    <div className="space-y-6 p-6 bg-gray-50 dark:bg-gray-950 min-h-screen">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <button onClick={onBack} className="mt-1 p-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50"><ArrowLeft className="w-4 h-4" /></button>
+          <div>
+            <h1 className="text-2xl font-bold flex items-center gap-2">{club.name} {!club.isActive && <span className="px-2 py-0.5 bg-gray-100 text-xs rounded-full">Inactive</span>}</h1>
+            <p className="text-sm text-gray-500 mt-1">{club.description}</p>
+            <span className="inline-block mt-2 px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded">{club.category}</span>
+          </div>
+        </div>
+        {isFounder && <button onClick={() => setConfirmDelete(true)} className="inline-flex items-center gap-1.5 px-3 py-2 border border-red-200 text-red-600 text-sm rounded-lg hover:bg-red-50"><Trash2 className="w-4 h-4" /> Delete Club</button>}
+      </div>
+
+      <div className="flex flex-wrap gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1 w-fit">
+        {(["announcements", "members", "requests", "events"] as const).map((t) => (
+          <button key={t} onClick={() => setActiveTab(t)} className={`px-4 py-2 rounded-md text-sm capitalize ${activeTab === t ? "bg-white shadow-sm" : "text-gray-500"}`}>
+            {t} {t === "requests" && club.pendingRequests.length > 0 && <span className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-500 text-white text-xs rounded-full flex items-center justify-center">{club.pendingRequests.length}</span>}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "announcements" && (
+        <div className="space-y-4 max-w-3xl">
+          {isAdmin && (
+            <div className="bg-white p-4 rounded-xl border">
+              <label className="block text-sm font-medium mb-2 flex items-center gap-2"><Megaphone className="w-4 h-4 text-blue-600" /> Post an Announcement</label>
+              <textarea value={announcementText} onChange={(e) => setAnnouncementText(e.target.value)} className="w-full px-3 py-2 border rounded-lg text-sm min-h-[100px]" />
+              <div className="flex justify-end mt-3"><button onClick={handlePostAnnouncement} disabled={posting || !announcementText.trim()} className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg"><Send className="w-4 h-4 inline mr-1" /> Post Message</button></div>
+            </div>
+          )}
+          <div className="space-y-3">
+            {(!club.announcements || club.announcements.length === 0) ? (<div className="bg-white p-8 text-center text-sm text-gray-500 rounded-xl border">No announcements yet.</div>) : (
+              club.announcements.map((ann) => (
+                <div key={ann._id} className="bg-white p-5 rounded-xl border relative group">
+                  <div className="flex items-center gap-3 mb-2">
+                    <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center text-blue-700 text-xs font-bold">{ann.postedBy.name.charAt(0).toUpperCase()}</div>
+                    <div><p className="font-semibold text-sm">{ann.postedBy.name}</p><p className="text-xs text-gray-500"><Clock className="w-3 h-3 inline" /> {new Date(ann.date).toLocaleString()}</p></div>
+                  </div>
+                  <p className="text-sm whitespace-pre-wrap">{ann.message}</p>
+                  {isAdmin && <button onClick={() => handleDeleteAnnouncement(ann._id)} className="absolute top-4 right-4 p-1.5 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100"><Trash2 className="w-4 h-4" /></button>}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      {activeTab === "members" && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {club.members.map((m) => {
+            const getSafeId = (entity: any) => typeof entity === "object" ? String(entity._id || entity.id) : String(entity);
+            const mId = getSafeId(m.user);
+            const memberIsAdmin = club.admins.some((a) => getSafeId(a) === mId);
+            const memberIsFounder = getSafeId(club.createdBy) === mId;
+            const isSelfCard = mId === currentUserId;
+
+            return (
+              <div key={m.user._id} className="bg-white p-4 rounded-xl border">
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center font-bold">{m.user.name.charAt(0).toUpperCase()}</div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-sm flex items-center gap-1.5">{m.user.name} {memberIsFounder && <Crown className="w-4 h-4 text-amber-500" />} {!memberIsFounder && memberIsAdmin && <Shield className="w-4 h-4 text-blue-500" />}</h3>
+                    <p className="text-xs text-gray-500 truncate">{m.user.email}</p>
+                    <p className="text-xs text-gray-400 mt-0.5">Joined {new Date(m.joinedAt).toLocaleDateString()}</p>
+                  </div>
+                </div>
+                <div className="mt-4 pt-3 border-t flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-gray-500">Role:</span>
+                    {isAdmin && !memberIsFounder ? (
+                      <select value={m.role} onChange={(e) => handleRoleChange(m.user._id, e.target.value)} className="text-xs border rounded px-2 py-1 capitalize">
+                        {ROLES.map((r) => <option key={r} value={r}>{r}</option>)}
+                      </select>
+                    ) : (<span className="text-xs font-medium capitalize bg-gray-100 px-2 py-1 rounded">{m.role}</span>)}
+                  </div>
+                  {isAdmin && !memberIsFounder && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-gray-500">Admin Access:</span>
+                      <button onClick={() => handleToggleAdmin(m.user._id, !memberIsAdmin)} className={`text-xs px-2 py-1 rounded ${memberIsAdmin ? "bg-blue-100 text-blue-700" : "bg-gray-100 text-gray-600"}`}>{memberIsAdmin ? "Revoke Admin" : "Make Admin"}</button>
+                    </div>
+                  )}
+                  <div className="flex justify-end mt-1">
+                    {canKick && !memberIsFounder && !isSelfCard && (<button onClick={() => handleRemoveMember(m.user._id)} className="text-xs text-red-600 hover:underline"><UserX className="w-3 h-3 inline" /> Kick Member</button>)}
+                    {isSelfCard && !isFounder && (<button onClick={() => handleRemoveMember(m.user._id)} className="text-xs text-red-600 hover:underline">Leave Club</button>)}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {activeTab === "requests" && (
+        <div className="space-y-3">
+          {!isAdmin ? (<div className="bg-white p-8 text-center text-sm text-gray-500 rounded-xl border">Only admins can manage requests.</div>) : club.pendingRequests.length === 0 ? (<div className="bg-white p-8 text-center text-sm text-gray-500 rounded-xl border">No pending requests.</div>) : (
+            club.pendingRequests.map((r) => (
+              <div key={r.user._id} className="bg-white p-4 rounded-xl border flex items-center justify-between gap-4">
+                <div className="min-w-0"><p className="font-medium">{r.user.name}</p><p className="text-xs text-gray-500">{r.user.email}</p><p className="text-xs text-gray-400 mt-1">Requested {new Date(r.requestedAt).toLocaleDateString()}</p></div>
+                <div className="flex gap-2"><button onClick={() => handleApprove(r.user._id)} className="px-3 py-1.5 bg-emerald-600 text-white text-sm rounded-lg">Approve</button><button onClick={() => handleReject(r.user._id)} className="px-3 py-1.5 border text-sm rounded-lg">Reject</button></div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {activeTab === "events" && (
+        <div className="space-y-4">
+          {isAdmin && (<div className="bg-white p-4 rounded-xl border flex gap-2"><select value={selectedEvent} onChange={(e) => setSelectedEvent(e.target.value)} className="flex-1 px-3 py-2 border rounded-lg text-sm"><option value="">Select an event...</option>{linkableEvents.map((e) => <option key={e._id} value={e._id}>{e.title}</option>)}</select><button onClick={handleLinkEvent} disabled={!selectedEvent} className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg disabled:opacity-50">Link</button></div>)}
+          {club.events.length === 0 ? (<div className="bg-white p-8 text-center text-sm text-gray-500 rounded-xl border">No events linked.</div>) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {club.events.map((ev) => (
+                <div key={ev._id} className="bg-white p-4 rounded-xl border flex items-center justify-between"><p className="font-medium text-sm">{ev.title}</p>{isAdmin && <button onClick={() => handleUnlinkEvent(ev._id)} className="p-1.5 text-red-500 hover:bg-red-50 rounded-md"><Unlink className="w-4 h-4" /></button>}</div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {confirmDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-gray-900/50" onClick={() => setConfirmDelete(false)} />
+          <div className="relative bg-white rounded-xl shadow-xl p-6 max-w-sm w-full"><h3 className="font-semibold mb-2">Delete Club</h3><p className="text-sm text-gray-600 mb-6">Are you sure? This cannot be undone.</p><div className="flex gap-3 justify-end"><button onClick={() => setConfirmDelete(false)} className="px-4 py-2 text-sm border rounded-lg">Cancel</button><button onClick={handleDeleteClub} className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg">Delete Forever</button></div></div>
+        </div>
+      )}
+    </div>
+  );
+};
+export default ClubManagement;

--- a/collegems-client/src/common-components-management/Clubs.tsx
+++ b/collegems-client/src/common-components-management/Clubs.tsx
@@ -1,0 +1,243 @@
+import React, { useEffect, useState } from "react";
+import {
+  Users, Plus, Search, X, CheckCircle, AlertTriangle,
+  Crown, Shield, UserPlus, Calendar, Settings, ChevronRight,
+  Building2, RefreshCw,
+} from "lucide-react";
+import api from "../api/axios";
+import ClubManagement from "./ClubManagement";
+
+interface MemberUser { _id: string; name: string; email: string; role: string; }
+interface Member { user: MemberUser; role: string; joinedAt: string; }
+interface ClubEvent { _id: string; title: string; date: string; status: string; category: string; }
+interface Club {
+  _id: string; name: string; description: string; category: string; logo?: string;
+  createdBy: MemberUser; admins: MemberUser[]; members: Member[];
+  pendingRequests: { user: MemberUser; message?: string; requestedAt: string }[];
+  events: ClubEvent[]; maxMembers: number; isActive: boolean;
+}
+
+const CATEGORIES = ["Technical", "Cultural", "Sports", "Literary", "Social Service", "Arts", "Music", "Dance", "Photography", "Entrepreneurship", "Other"];
+const inputCls = "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500";
+const selectCls = "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500";
+const labelCls = "block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1";
+
+const Clubs: React.FC = () => {
+  // THE FIX: Move ID extraction INSIDE the component so it updates on every login!
+  const getSafeUserId = () => {
+    try {
+      const data = JSON.parse(localStorage.getItem("userData") || "{}");
+      const id = data._id || data.id || data.userId || (data.user && (data.user._id || data.user.id));
+      return id ? String(id) : "MISSING_ID";
+    } catch {
+      return "MISSING_ID";
+    }
+  };
+  const currentUserId = getSafeUserId();
+
+  const [tab, setTab] = useState<"all" | "mine">("all");
+  const [clubs, setClubs] = useState<Club[]>([]);
+  const [myClubs, setMyClubs] = useState<Club[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
+  const [managingClub, setManagingClub] = useState<Club | null>(null);
+  const [toast, setToast] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+  const [form, setForm] = useState({ name: "", description: "", category: "Technical", maxMembers: "100" });
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  const showToast = (type: "success" | "error", msg: string) => {
+    setToast({ type, msg });
+    setTimeout(() => setToast(null), 4000);
+  };
+
+  const fetchClubs = async () => {
+    setLoading(true);
+    try {
+      const params: Record<string, string> = {};
+      if (category) params.category = category;
+      if (search) params.search = search;
+      const res = await api.get("/clubs", { params });
+      setClubs(res.data);
+    } catch {
+      showToast("error", "Failed to load clubs");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchMyClubs = async () => {
+    try {
+      const res = await api.get("/clubs/my");
+      setMyClubs(res.data);
+    } catch {
+      showToast("error", "Failed to load your clubs");
+    }
+  };
+
+  useEffect(() => { fetchClubs(); fetchMyClubs(); }, []);
+  useEffect(() => { const t = setTimeout(fetchClubs, 300); return () => clearTimeout(t); }, [search, category]);
+
+  const refreshAll = () => { fetchClubs(); fetchMyClubs(); };
+
+  // ─── DYNAMIC IDENTIFICATION ───
+  const isMe = (entity: any) => {
+    if (!entity || currentUserId === "MISSING_ID") return false;
+    const id = typeof entity === "object" ? (entity._id || entity.id) : entity;
+    return String(id) === currentUserId;
+  };
+
+  const isFounder = (club: Club) => isMe(club?.createdBy);
+  const isAdmin = (club: Club) => isFounder(club) || (club?.admins || []).some(isMe);
+  const isMember = (club: Club) => (club?.members || []).some(m => isMe(m?.user));
+  
+  const hasPendingRequest = (club: Club) => 
+    !isAdmin(club) && !isMember(club) && (club?.pendingRequests || []).some(r => isMe(r?.user));
+    
+  const myRole = (club: Club) => {
+    if (isFounder(club)) return "president"; // Overrides database glitches
+    return (club?.members || []).find(m => isMe(m?.user))?.role || "member";
+  };
+
+  const handleJoin = async (clubId: string) => {
+    try {
+      await api.post(`/clubs/${clubId}/join`, {});
+      showToast("success", "Join request submitted");
+      refreshAll();
+    } catch (err: any) {
+      showToast("error", err?.response?.data?.message || "Failed to send join request");
+    }
+  };
+
+  const handleCreate = async () => {
+    if (!form.name.trim() || !form.description.trim()) { setFormError("Name and description are required."); return; }
+    setSubmitting(true); setFormError("");
+    try {
+      await api.post("/clubs", { ...form, maxMembers: Number(form.maxMembers) || 100 });
+      showToast("success", "Club created successfully");
+      setShowCreate(false); setForm({ name: "", description: "", category: "Technical", maxMembers: "100" });
+      refreshAll();
+    } catch (err: any) { setFormError(err?.response?.data?.message || "Failed to create club"); } 
+    finally { setSubmitting(false); }
+  };
+
+const roleIcon = (role: string) => {
+    if (role === "president") return <Crown className="w-3.5 h-3.5 text-amber-500" />;
+    if (["vice-president", "secretary", "treasurer", "coordinator"].includes(role)) return <Shield className="w-3.5 h-3.5 text-blue-500" />;
+    return null;
+  };
+
+  const list = tab === "all" ? clubs : myClubs;
+
+  if (managingClub) {
+    return <ClubManagement club={managingClub} onBack={() => { setManagingClub(null); refreshAll(); }} onUpdated={(updated) => { setManagingClub(updated); refreshAll(); }} showToast={showToast} />;
+  }
+
+  return (
+    <div className="space-y-6 p-6 bg-gray-50 dark:bg-gray-950 min-h-screen">
+      {toast && <div className={`fixed top-4 right-4 z-50 flex items-center gap-2 px-4 py-3 rounded-lg shadow-lg text-sm font-medium text-white ${toast.type === "success" ? "bg-green-600" : "bg-red-600"}`}>{toast.type === "success" ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}{toast.msg}</div>}
+
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2"><Users className="w-6 h-6 text-blue-600 dark:text-blue-400" />Clubs & Organizations</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Discover, join, and manage student clubs</p>
+        </div>
+        <button onClick={() => setShowCreate(true)} className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors"><Plus className="w-4 h-4" /> Create Club</button>
+      </div>
+
+      <div className="flex gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1 w-fit">
+        {(["all", "mine"] as const).map((t) => (
+          <button key={t} onClick={() => setTab(t)} className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${tab === t ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm" : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"}`}>{t === "all" ? "All Clubs" : `My Clubs (${myClubs.length})`}</button>
+        ))}
+      </div>
+
+      {tab === "all" && (
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="flex-1 relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={16} />
+              <input type="text" placeholder="Search clubs by name…" className={`${inputCls} pl-9`} value={search} onChange={(e) => setSearch(e.target.value)} />
+            </div>
+            <select className="w-44 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-700" value={category} onChange={(e) => setCategory(e.target.value)}>
+              <option value="">All Categories</option>
+              {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+            </select>
+            <button onClick={refreshAll} className="p-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"><RefreshCw className="w-4 h-4" /></button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-12 text-center"><div className="inline-block animate-spin rounded-full h-8 w-8 border-2 border-blue-600 border-t-transparent" /><p className="mt-3 text-sm text-gray-500 dark:text-gray-400">Loading clubs…</p></div>
+      ) : list.length === 0 ? (
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-12 text-center"><Building2 className="w-12 h-12 text-gray-300 dark:text-gray-600 mx-auto mb-3" /><p className="font-medium text-gray-900 dark:text-white mb-1">{tab === "all" ? "No clubs found" : "You haven't joined any clubs yet"}</p></div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
+          {list.map((club) => {
+            const isMem = isMember(club); const isAdm = isAdmin(club); const pending = hasPendingRequest(club);
+            return (
+              <div key={club._id} className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 hover:shadow-md transition-shadow">
+                <div className="flex items-start justify-between mb-3">
+                  <div className="min-w-0 flex-1">
+                    <h3 className="font-semibold text-gray-900 dark:text-white truncate">{club.name}</h3>
+                    <span className="inline-block mt-1 px-2 py-0.5 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs font-medium rounded">{club.category}</span>
+                  </div>
+                  {isAdm && <span className="inline-flex items-center gap-1 px-2 py-1 bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 text-xs font-medium rounded-full"><Crown className="w-3 h-3" /> Admin</span>}
+                </div>
+                <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2 mb-4">{club.description}</p>
+                <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mb-4">
+                  <span className="flex items-center gap-1.5"><Users className="w-3.5 h-3.5" /> {club.members.length} / {club.maxMembers} members</span>
+                  <span className="flex items-center gap-1.5"><Calendar className="w-3.5 h-3.5" /> {club.events.length} events</span>
+                </div>
+                {isMem && (
+                  <div className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300 mb-3">
+                    {roleIcon(myRole(club))} Your role: <span className="font-medium capitalize">{myRole(club)}</span>
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  {isAdm || isFounder(club) ? (
+                    <button onClick={() => setManagingClub(club)} className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"><Settings className="w-4 h-4" /> Manage</button>
+                  ) : isMem ? (
+                    <button onClick={() => setManagingClub(club)} className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">View Club <ChevronRight className="w-4 h-4" /></button>
+                  ) : pending ? (
+                    <button disabled className="flex-1 px-3 py-2 bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed">Request Pending</button>
+                  ) : (
+                    <button onClick={() => handleJoin(club._id)} disabled={club.members.length >= club.maxMembers} className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"><UserPlus className="w-4 h-4" />{club.members.length >= club.maxMembers ? "Club Full" : "Request to Join"}</button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {showCreate && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-gray-900/50 backdrop-blur-sm" onClick={() => setShowCreate(false)} />
+          <div className="relative w-full max-w-lg bg-white dark:bg-gray-800 rounded-xl shadow-xl overflow-hidden">
+            <div className="flex items-center justify-between px-6 py-4 bg-blue-600">
+              <h3 className="text-lg font-semibold text-white">Create New Club</h3>
+              <button onClick={() => setShowCreate(false)} className="text-white/80 hover:text-white"><X className="w-5 h-5" /></button>
+            </div>
+            <div className="p-6 space-y-4">
+              {formError && <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400"><AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />{formError}</div>}
+              <div><label className={labelCls}>Club Name *</label><input className={inputCls} value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} placeholder="e.g. Robotics Club" /></div>
+              <div><label className={labelCls}>Description *</label><textarea className={`${inputCls} min-h-[90px]`} value={form.description} onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))} placeholder="What does this club do?" /></div>
+              <div className="grid grid-cols-2 gap-3">
+                <div><label className={labelCls}>Category</label><select className={selectCls} value={form.category} onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))}>{CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}</select></div>
+                <div><label className={labelCls}>Max Members</label><input type="number" min={1} className={inputCls} value={form.maxMembers} onChange={(e) => setForm((f) => ({ ...f, maxMembers: e.target.value }))} /></div>
+              </div>
+            </div>
+            <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-3">
+              <button onClick={() => setShowCreate(false)} className="px-4 py-2 text-sm border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">Cancel</button>
+              <button onClick={handleCreate} disabled={submitting} className="px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium disabled:opacity-60">{submitting ? "Creating…" : "Create Club"}</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+export default Clubs;

--- a/collegems-client/src/hod-components/FacultyAssignment.tsx
+++ b/collegems-client/src/hod-components/FacultyAssignment.tsx
@@ -99,7 +99,12 @@ const FacultyAssignment: React.FC = () => {
       const params: Record<string, string> = { academicYear: filterYear };
       if (filterSemester) params.semester = filterSemester;
       const res = await api.get("/faculty-assignments/all", { params });
-      setAssignments(res.data);
+      
+      // Safety Check
+      if (Array.isArray(res.data)) setAssignments(res.data);
+      else if (res.data?.data && Array.isArray(res.data.data)) setAssignments(res.data.data);
+      else setAssignments([]);
+
     } catch {
       showToast("error", "Failed to load assignments");
     } finally {
@@ -112,7 +117,7 @@ const FacultyAssignment: React.FC = () => {
       const res = await api.get("/faculty-assignments/workload", {
         params: { academicYear: filterYear },
       });
-      setWorkload(res.data.workload);
+      setWorkload(Array.isArray(res.data?.workload) ? res.data.workload : []);
     } catch {
       showToast("error", "Failed to load workload data");
     }
@@ -124,8 +129,21 @@ const FacultyAssignment: React.FC = () => {
         api.get("/users/teachers"),
         api.get("/courses/all"),
       ]);
-      setTeachers(tRes.data);
-      setCourses(cRes.data);
+      
+      // Safety Checks for Teachers
+      const fetchedTeachers = tRes.data;
+      if (Array.isArray(fetchedTeachers)) setTeachers(fetchedTeachers);
+      else if (fetchedTeachers?.data && Array.isArray(fetchedTeachers.data)) setTeachers(fetchedTeachers.data);
+      else if (fetchedTeachers?.teachers && Array.isArray(fetchedTeachers.teachers)) setTeachers(fetchedTeachers.teachers);
+      else setTeachers([]);
+
+      // Safety Checks for Courses
+      const fetchedCourses = cRes.data;
+      if (Array.isArray(fetchedCourses)) setCourses(fetchedCourses);
+      else if (fetchedCourses?.data && Array.isArray(fetchedCourses.data)) setCourses(fetchedCourses.data);
+      else if (fetchedCourses?.courses && Array.isArray(fetchedCourses.courses)) setCourses(fetchedCourses.courses);
+      else setCourses([]);
+
     } catch {
       showToast("error", "Failed to load form data");
     }
@@ -164,7 +182,8 @@ const FacultyAssignment: React.FC = () => {
   };
 
   const handleCourseChange = (courseId: string) => {
-    const course = courses.find((c) => c._id === courseId);
+    const safeCourses = Array.isArray(courses) ? courses : [];
+    const course = safeCourses.find((c) => c._id === courseId);
     setForm((f) => ({
       ...f,
       course: courseId,
@@ -212,18 +231,20 @@ const FacultyAssignment: React.FC = () => {
   };
 
   // ─── Filtering ──────────────────────────────────────────────────────────────
-  const filtered = assignments.filter((a) => {
+  const safeAssignments = Array.isArray(assignments) ? assignments : [];
+  const filtered = safeAssignments.filter((a) => {
     const q = search.toLowerCase();
     return (
-      a.faculty.name.toLowerCase().includes(q) ||
-      a.course.name.toLowerCase().includes(q) ||
-      a.course.code.toLowerCase().includes(q) ||
-      a.section.toLowerCase().includes(q)
+      a.faculty?.name?.toLowerCase().includes(q) ||
+      a.course?.name?.toLowerCase().includes(q) ||
+      a.course?.code?.toLowerCase().includes(q) ||
+      a.section?.toLowerCase().includes(q)
     );
   });
 
   // ─── Stats ──────────────────────────────────────────────────────────────────
-  const overloadedCount = workload.filter((w) => w.isOverloaded).length;
+  const safeWorkload = Array.isArray(workload) ? workload : [];
+  const overloadedCount = safeWorkload.filter((w) => w.isOverloaded).length;
 
   // ─── Render ─────────────────────────────────────────────────────────────────
   return (
@@ -272,19 +293,19 @@ const FacultyAssignment: React.FC = () => {
         {[
           {
             label: "Total Assignments",
-            value: assignments.length,
+            value: safeAssignments.length,
             icon: <BookOpen className="w-5 h-5 text-blue-600 dark:text-blue-400" />,
             bg: "bg-blue-50 dark:bg-blue-900/30",
           },
           {
             label: "Faculty Assigned",
-            value: new Set(assignments.map((a) => a.faculty._id)).size,
+            value: new Set(safeAssignments.filter(a => a.faculty?._id).map((a) => a.faculty._id)).size,
             icon: <Users className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />,
             bg: "bg-emerald-50 dark:bg-emerald-900/30",
           },
           {
             label: "Sections Covered",
-            value: new Set(assignments.map((a) => a.section)).size,
+            value: new Set(safeAssignments.filter(a => a.section).map((a) => a.section)).size,
             icon: <UserCheck className="w-5 h-5 text-purple-600 dark:text-purple-400" />,
             bg: "bg-purple-50 dark:bg-purple-900/30",
           },
@@ -408,14 +429,14 @@ const FacultyAssignment: React.FC = () => {
                       <tr key={a._id} className="hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors">
                         <td className="px-4 py-3">
                           <div>
-                            <p className="font-medium text-gray-900 dark:text-white">{a.faculty.name}</p>
-                            <p className="text-xs text-gray-500 dark:text-gray-400">{a.faculty.teacherId}</p>
+                            <p className="font-medium text-gray-900 dark:text-white">{a.faculty?.name || "Unknown"}</p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">{a.faculty?.teacherId || "N/A"}</p>
                           </div>
                         </td>
                         <td className="px-4 py-3">
                           <div>
-                            <p className="font-medium text-gray-900 dark:text-white">{a.course.name}</p>
-                            <p className="text-xs text-gray-500 dark:text-gray-400">{a.course.code}</p>
+                            <p className="font-medium text-gray-900 dark:text-white">{a.course?.name || "Unknown"}</p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">{a.course?.code || "N/A"}</p>
                           </div>
                         </td>
                         <td className="px-4 py-3">
@@ -449,7 +470,7 @@ const FacultyAssignment: React.FC = () => {
                 </table>
               </div>
               <div className="px-4 py-3 border-t border-gray-100 dark:border-gray-700 text-xs text-gray-500 dark:text-gray-400">
-                Showing {filtered.length} of {assignments.length} assignments
+                Showing {filtered.length} of {safeAssignments.length} assignments
               </div>
             </div>
           )}
@@ -469,7 +490,7 @@ const FacultyAssignment: React.FC = () => {
             </div>
           )}
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-            {workload.map((w) => {
+            {safeWorkload.map((w) => {
               const pct = Math.min((w.assignmentCount / w.workloadLimit) * 100, 100);
               const color =
                 w.isOverloaded
@@ -507,7 +528,7 @@ const FacultyAssignment: React.FC = () => {
                     </div>
                   </div>
                   <div className="flex flex-wrap gap-1.5">
-                    {w.sections.map((sec) => (
+                    {(Array.isArray(w.sections) ? w.sections : []).map((sec) => (
                       <span key={sec} className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs rounded">
                         Sec {sec}
                       </span>
@@ -516,7 +537,7 @@ const FacultyAssignment: React.FC = () => {
                 </div>
               );
             })}
-            {workload.length === 0 && (
+            {safeWorkload.length === 0 && (
               <div className="col-span-full bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-12 text-center">
                 <BarChart2 className="w-12 h-12 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
                 <p className="text-gray-500 dark:text-gray-400">No workload data for {filterYear}</p>
@@ -558,7 +579,7 @@ const FacultyAssignment: React.FC = () => {
                     onChange={(e) => setForm((f) => ({ ...f, faculty: e.target.value }))}
                   >
                     <option value="">Select faculty…</option>
-                    {teachers.map((t) => (
+                    {(Array.isArray(teachers) ? teachers : []).map((t) => (
                       <option key={t._id} value={t._id}>
                         {t.name} ({t.teacherId})
                       </option>
@@ -575,7 +596,7 @@ const FacultyAssignment: React.FC = () => {
                     onChange={(e) => handleCourseChange(e.target.value)}
                   >
                     <option value="">Select course…</option>
-                    {courses.map((c) => (
+                    {(Array.isArray(courses) ? courses : []).map((c) => (
                       <option key={c._id} value={c._id}>
                         {c.name} ({c.code})
                       </option>

--- a/collegems-client/src/hod-components/Teachers.tsx
+++ b/collegems-client/src/hod-components/Teachers.tsx
@@ -5,7 +5,7 @@ import {
   UserCircle, GraduationCap, BookOpen, ChevronRight, Filter, Clock, MapPin, Wifi,
 } from "lucide-react";
 import api from "../api/axios";
-import { useTheme } from "../context/ThemeContext";
+
 
 interface Teacher {
   _id?: string;

--- a/collegems-client/src/pages/HODDashboard.tsx
+++ b/collegems-client/src/pages/HODDashboard.tsx
@@ -29,6 +29,7 @@ import ExamHalls from "../hod-components/ExamHalls";
 import FeedbackManagement from "../hod-components/FeedbackManagement";
 import HallAllocation from "../hod-components/HallAllocation";
 import FacultyAssignment from "../hod-components/FacultyAssignment";
+import Clubs from "../common-components-management/Clubs";
 type TabType =
   | "overview"
   | "announcements"
@@ -55,7 +56,8 @@ type TabType =
   | "audit-logs"
   | "manage-bookings"
   | "manage-resources" 
-  | "faculty-assignment";
+  | "faculty-assignment"
+  | "clubs" ;
 
 interface Data {
   cards: Array<{ title: string; value: number }>;
@@ -122,6 +124,7 @@ export default function HODDashboard() {
     { id: "manage-bookings" as TabType, label: "Manage Bookings", icon: Calendar },
     { id: "manage-resources" as TabType, label: "Manage Resources", icon: Building2 },
     { id: "faculty-assignment" as TabType, label: "Faculty Assignments", icon: Users },
+     { id: "clubs" as TabType, label: "Clubs & Organizations", icon: Users },
   ];
 
   useEffect(() => {
@@ -318,6 +321,7 @@ export default function HODDashboard() {
         {activeTab === "manage-bookings" && <BookingManagement />}
         {activeTab === "manage-resources" && <ResourceManagement />}
         {activeTab === "faculty-assignment" && <FacultyAssignment />}
+        {activeTab === "clubs" && <Clubs />}
       </>
     );
   };

--- a/collegems-client/src/pages/HODDashboard.tsx
+++ b/collegems-client/src/pages/HODDashboard.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTheme } from "../context/ThemeContext";
 import {
   LayoutGrid, Users, GraduationCap, BookOpen, Building2, FileText,
   Wallet, DollarSign, Calendar, Menu, X, RefreshCw, ChevronRight,
   Bell, Search, UserCircle, LogOut, Settings, CalendarDays,
-  Moon, Sun,
+  Moon, Sun, MessageSquare, Award, Bus
 } from "lucide-react";
 import api from "../api/axios";
 import Students from "../common-components-management/Students";
@@ -17,9 +17,21 @@ import Library from "../common-components-management/Library";
 import HODSettings from "../hod-components/Settings";
 import HODCourses from "../hod-components/Courses";
 import HODExamForms from "../hod-components/ExamForms";
-
+import ResourceManagement from "../hod-components/ResourceManagement";
+import BookingManagement from "../hod-components/BookingManagement";
+import AnnouncementForm from "../common-components-management/AnnouncementForm";
+import AnnouncementManage from "../common-components-management/AnnouncementManage";
+import BusRoutes from "../common-components-management/BusRoutes";
+import Scholarships from "../common-components-management/Scholarships";
+import AuditLogs from "../hod-components/AuditLogs";
+import ExamForms from "../hod-components/ExamForms";
+import ExamHalls from "../hod-components/ExamHalls";
+import FeedbackManagement from "../hod-components/FeedbackManagement";
+import HallAllocation from "../hod-components/HallAllocation";
+import FacultyAssignment from "../hod-components/FacultyAssignment";
 type TabType =
   | "overview"
+  | "announcements"
   | "teachers"
   | "teachers-attendance"
   | "students"
@@ -34,7 +46,16 @@ type TabType =
   | "library"
   | "settings"
   | "reports"
-  | "exam-forms";
+  | "exam-forms"
+  | "feedback"
+  | "scholarships"
+  | "bus-routes"
+  | "exam-halls"
+  | "hall-allocation"
+  | "audit-logs"
+  | "manage-bookings"
+  | "manage-resources" 
+  | "faculty-assignment";
 
 interface Data {
   cards: Array<{ title: string; value: number }>;
@@ -53,42 +74,77 @@ interface ProfileData {
 export default function HODDashboard() {
   const navigate = useNavigate();
   const { darkMode, toggleTheme } = useTheme();
+  
+  // Dashboard states
   const [data, setData] = useState<Data | null>(null);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<TabType>("overview");
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  
+  // Profile states
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [profileLoading, setProfileLoading] = useState(true);
   const [profileRefreshing, setProfileRefreshing] = useState(false);
   const [profileError, setProfileError] = useState<string | null>(null);
   const [profileUpdatedAt, setProfileUpdatedAt] = useState<Date | null>(null);
 
+  // Search states
   const [searchTerm, setSearchTerm] = useState("");
-
   const [searchData, setSearchData] = useState({
     students: [],
     teachers: [],
     courses: [],
   });
 
-  const [searchResults, setSearchResults] = useState({
-    students: [],
-    teachers: [],
-    courses: [],
-  });
+  const navigationItems = [
+    { id: "overview" as TabType, label: "Overview", icon: LayoutGrid },
+    { id: "announcements" as TabType, label: "Announcements", icon: Bell },
+    { id: "teachers" as TabType, label: "Teachers", icon: Users },
+    { id: "teachers-attendance" as TabType, label: "Teachers Attendance", icon: Users },
+    { id: "students" as TabType, label: "Students", icon: GraduationCap },
+    { id: "academic-calendar" as TabType, label: "Academic Calendar", icon: Calendar },
+    { id: "courses" as TabType, label: "Courses", icon: BookOpen },
+    { id: "classes" as TabType, label: "Classes", icon: Building2 },
+    { id: "syllabus" as TabType, label: "Syllabus", icon: FileText },
+    { id: "fees" as TabType, label: "Fees", icon: Wallet },
+    { id: "salary" as TabType, label: "Salary", icon: DollarSign },
+    { id: "examSchedule" as TabType, label: "Exam Schedule", icon: Calendar },
+    { id: "events" as TabType, label: "Organize Events", icon: CalendarDays },
+    { id: "library" as TabType, label: "Library Catalog", icon: BookOpen },
+    { id: "reports" as TabType, label: "Report Generator", icon: FileText },
+    { id: "feedback" as TabType, label: "Feedback", icon: MessageSquare },
+    { id: "exam-forms" as TabType, label: "Exam Forms", icon: FileText },
+    { id: "scholarships" as TabType, label: "Scholarship Approvals", icon: Award },
+    { id: "bus-routes" as TabType, label: "Bus Routes Management", icon: Bus },
+    { id: "exam-halls" as TabType, label: "Exam Halls", icon: Building2 },
+    { id: "hall-allocation" as TabType, label: "Hall Allocation", icon: Users },
+    { id: "audit-logs" as TabType, label: "Audit Logs", icon: FileText },
+    { id: "manage-bookings" as TabType, label: "Manage Bookings", icon: Calendar },
+    { id: "manage-resources" as TabType, label: "Manage Resources", icon: Building2 },
+    { id: "faculty-assignment" as TabType, label: "Faculty Assignments", icon: Users },
+  ];
 
   useEffect(() => {
     fetchDashboardData();
     fetchProfileData();
     fetchSearchData();
+    
     const refreshProfile = () => fetchProfileData(true);
     const profileInterval = window.setInterval(refreshProfile, 15000);
     window.addEventListener("focus", refreshProfile);
+    
     return () => {
       window.clearInterval(profileInterval);
       window.removeEventListener("focus", refreshProfile);
     };
   }, []);
+
+  const handleSignOut = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("role");
+    localStorage.removeItem("userData");
+    navigate("/login", { replace: true });
+  };
 
   const fetchDashboardData = async () => {
     try {
@@ -109,10 +165,7 @@ export default function HODDashboard() {
       const res = await api.get("/users/me");
       const user = res.data;
       if (user?.role !== "hod") {
-        localStorage.removeItem("token");
-        localStorage.removeItem("role");
-        localStorage.removeItem("userData");
-        navigate("/login", { replace: true });
+        handleSignOut();
         return;
       }
       setProfile({
@@ -126,10 +179,7 @@ export default function HODDashboard() {
     } catch (error: any) {
       const status = error?.response?.status;
       if (status === 401 || status === 403) {
-        localStorage.removeItem("token");
-        localStorage.removeItem("role");
-        localStorage.removeItem("userData");
-        navigate("/login", { replace: true });
+        handleSignOut();
         return;
       }
       setProfileError(error?.response?.data?.message || "Unable to load HOD profile.");
@@ -157,387 +207,252 @@ export default function HODDashboard() {
     }
   };
 
-  useEffect(() => {
-    if (!searchTerm.trim()) {
-      setSearchResults({
-        students: [],
-        teachers: [],
-        courses: [],
-      });
-      return;
-    }
-
-    const query = searchTerm.toLowerCase();
-
-    setSearchResults({
+  const searchResults = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    if (!query) return { students: [], teachers: [], courses: [] };
+    
+    return {
       students: searchData.students.filter(
         (student: any) =>
           student.name?.toLowerCase().includes(query) ||
           student.email?.toLowerCase().includes(query)
       ),
-
       teachers: searchData.teachers.filter(
         (teacher: any) =>
           teacher.name?.toLowerCase().includes(query) ||
           teacher.email?.toLowerCase().includes(query)
       ),
-
-  
-
-  interface ProfileData {
-    name: string;
-    email: string;
-    phone?: string;
-    department?: string;
-    departmentCode?: string;
-    role: string;
-    avatarUrl?: string;
-  }
-
-  const navigationItems = [
-    { id: "overview" as TabType, label: "Overview", icon: LayoutGrid },
-    { id: "announcements", label: "Announcements", icon: Bell },
-    { id: "teachers" as TabType, label: "Teachers", icon: Users },
-    { id: "teachers-attendance" as TabType, label: "Teachers Attendance", icon: Users },
-    { id: "students" as TabType, label: "Students", icon: GraduationCap },
-    { id: "academic-calendar" as TabType, label: "Academic Calendar", icon: Calendar },
-    { id: "courses" as TabType, label: "Courses", icon: BookOpen },
-    { id: "classes" as TabType, label: "Classes", icon: Building2 },
-    { id: "syllabus" as TabType, label: "Syllabus", icon: FileText },
-    { id: "fees" as TabType, label: "Fees", icon: Wallet },
-    { id: "salary" as TabType, label: "Salary", icon: DollarSign },
-    { id: "examSchedule" as TabType, label: "Exam Schedule", icon: Calendar },
-    { id: "events" as TabType, label: "Organize Events", icon: CalendarDays },
-    { id: "library" as TabType, label: "Library Catalog", icon: BookOpen },
-    { id: "reports" as TabType, label: "Report Generator", icon: FileText },
-    { id: "feedback" as TabType, label: "Feedback", icon: MessageSquare },
-    { id: "exam-forms" as TabType, label: "Exam Forms", icon: FileText },
-    { id: "scholarships" as TabType, label: "Scholarship Approvals", icon: Award },
-    { id: "bus-routes" as TabType, label: "Bus Routes Management", icon: Bus },
-    { id: "exam-halls" as TabType, label: "Exam Halls", icon: Building2 },
-    { id: "hall-allocation" as TabType, label: "Hall Allocation", icon: Users },
-    { id: "audit-logs" as TabType, label: "Audit Logs", icon: FileText },
-    { id: "manage-bookings" as TabType, label: "Manage Bookings", icon: Calendar },
-    { id: "manage-resources" as TabType, label: "Manage Resources", icon: Building2 },
-  ];
-
-  export default function HODDashboard() {
-    const navigate = useNavigate();
-    const { darkMode, toggleTheme } = useTheme();
-    const [data, setData] = useState<Data | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [activeTab, setActiveTab] = useState<TabType>("overview");
-    const [sidebarOpen, setSidebarOpen] = useState(false);
-    const [profile, setProfile] = useState<ProfileData | null>(null);
-    const [searchTerm, setSearchTerm] = useState("");
-    const [searchData, setSearchData] = useState({ students: [], teachers: [], courses: [] });
-
-    useEffect(() => {
-      fetchDashboardData();
-      fetchProfileData();
-      fetchSearchData();
-    }, []);
-
-    const fetchDashboardData = async () => {
-      try {
-        setLoading(true);
-        const res = await api.get("/dashboard");
-        setData(res.data);
-      } catch (error) {
-        console.error("Error fetching dashboard data:", error);
-      } finally {
-        setLoading(false);
-      }
+      courses: searchData.courses.filter(
+        (course: any) =>
+          course.name?.toLowerCase().includes(query) ||
+          course.code?.toLowerCase().includes(query) ||
+          course.department?.toLowerCase().includes(query)
+      ),
     };
+  }, [searchTerm, searchData]);
 
-    const fetchProfileData = async () => {
-      try {
-        const res = await api.get("/users/me");
-        const user = res.data;
-        if (user?.role !== "hod") {
-          handleSignOut();
-          return;
-        }
-        setProfile({
-          name: user.name || "",
-          email: user.email || "",
-          phone: user.phone || "",
-          department: user.department || "",
-          departmentCode: user.departmentCode || "",
-          role: user.role || "hod",
-          avatarUrl: user.avatarUrl || user.profilePicture || user.photo,
-        });
-      } catch (error) {
-        console.error("Unable to load HOD profile:", error);
-      }
-    };
+  const statsCards = (data?.cards || []).map((card, index) => ({
+    ...card,
+    icon: [Users, GraduationCap, BookOpen, Building2][index % 4],
+    color: ["bg-blue-50 text-blue-700", "bg-amber-50 text-amber-700", "bg-emerald-50 text-emerald-700", "bg-purple-50 text-purple-700"][index % 4],
+  }));
 
-    const fetchSearchData = async () => {
-      try {
-        const [studentsRes, teachersRes, coursesRes] = await Promise.all([
-          api.get("/users/students"),
-          api.get("/users/teachers"),
-          api.get("/courses/all"),
-        ]);
-        setSearchData({
-          students: studentsRes.data || [],
-          teachers: teachersRes.data || [],
-          courses: coursesRes.data || [],
-        });
-      } catch (error) {
-        console.error("Error loading search data:", error);
-      }
-    };
+  const activeLabel = navigationItems.find((item) => item.id === activeTab)?.label || "Overview";
+  const profileDepartment = profile?.department || profile?.departmentCode || "Department not set";
+  const profileInitials = profile?.name
+    ?.split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
 
-    const handleSignOut = () => {
-      localStorage.removeItem("token");
-      localStorage.removeItem("role");
-      localStorage.removeItem("userData");
-      navigate("/login", { replace: true });
-    };
-
-    const searchResults = useMemo(() => {
-      const query = searchTerm.trim().toLowerCase();
-      if (!query) return { students: [], teachers: [], courses: [] };
-      return {
-        students: searchData.students.filter(
-          (student: any) =>
-            student.name?.toLowerCase().includes(query) ||
-            student.email?.toLowerCase().includes(query)
-        ),
-        teachers: searchData.teachers.filter(
-          (teacher: any) =>
-            teacher.name?.toLowerCase().includes(query) ||
-            teacher.email?.toLowerCase().includes(query)
-        ),
-        courses: searchData.courses.filter(
-          (course: any) =>
-            course.name?.toLowerCase().includes(query) ||
-            course.code?.toLowerCase().includes(query) ||
-            course.department?.toLowerCase().includes(query)
-        ),
-      };
-    }, [searchData, searchTerm]);
-
-    const statsCards = (data?.cards || []).map((card, index) => ({
-      ...card,
-      icon: [Users, GraduationCap, BookOpen, Building2][index % 4],
-      color: ["bg-blue-50 text-blue-700", "bg-amber-50 text-amber-700", "bg-emerald-50 text-emerald-700", "bg-purple-50 text-purple-700"][index % 4],
-    }));
-
-    const activeLabel = navigationItems.find((item) => item.id === activeTab)?.label || "Overview";
-    const profileDepartment = profile?.department || profile?.departmentCode || "Department not set";
-    const profileInitials = profile?.name
-      ?.split(" ")
-      .filter(Boolean)
-      .slice(0, 2)
-      .map((part) => part[0]?.toUpperCase())
-      .join("");
-
-    const renderTab = () => {
-      if (activeTab === "overview") {
-        return (
-          <div className="space-y-8">
-            <section className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-                {profile?.name || "HOD Profile"}
-              </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{profileDepartment}</p>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-3">{profile?.email || "No email available"}</p>
-            </section>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-              {statsCards.map((card, index) => {
-                const Icon = card.icon;
-                return (
-                  <div key={index} className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
-                    <div className="flex items-start justify-between">
-                      <div>
-                        <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{card.title}</p>
-                        <p className="text-2xl font-bold text-gray-900 dark:text-white">{card.value}</p>
-                      </div>
-                      <div className={`p-3 rounded-lg ${card.color}`}>
-                        <Icon className="w-5 h-5" />
-                      </div>
+  const renderTab = () => {
+    if (activeTab === "overview") {
+      return (
+        <div className="space-y-8">
+          <section className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              {profile?.name || "HOD Profile"}
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{profileDepartment}</p>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-3">{profile?.email || "No email available"}</p>
+          </section>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {statsCards.map((card, index) => {
+              const Icon = card.icon;
+              return (
+                <div key={index} className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{card.title}</p>
+                      <p className="text-2xl font-bold text-gray-900 dark:text-white">{card.value}</p>
+                    </div>
+                    <div className={`p-3 rounded-lg ${card.color}`}>
+                      <Icon className="w-5 h-5" />
                     </div>
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        );
-      }
-
-      const placeholders: Partial<Record<TabType, string>> = {
-        classes: "Class management is not connected on this dashboard yet.",
-        syllabus: "Syllabus management is not connected on this dashboard yet.",
-        fees: "Fee management is not connected on this dashboard yet.",
-        examSchedule: "Use the exam schedule route to manage exam schedules.",
-        events: "Event management is not connected on this dashboard yet.",
-      };
-
-      if (placeholders[activeTab]) {
-        return <div className="text-sm text-gray-600 dark:text-gray-300">{placeholders[activeTab]}</div>;
-      }
-
-      return (
-        <>
-          {activeTab === "announcements" && (
-            <div className="space-y-8">
-              <AnnouncementForm />
-              <hr className="border-gray-200 dark:border-gray-700" />
-              <AnnouncementManage />
-            </div>
-          )}
-          {activeTab === "teachers" && <Teachers />}
-          {activeTab === "teachers-attendance" && <HODTeacherAttendance />}
-          {activeTab === "students" && <Students />}
-          {activeTab === "salary" && <HODSalary />}
-          {activeTab === "academic-calendar" && <AcademicCalendar role="hod" />}
-          {activeTab === "library" && <Library />}
-          {activeTab === "courses" && <HODCourses />}
-          {activeTab === "settings" && <HODSettings />}
-          {activeTab === "feedback" && <FeedbackManagement />}
-          {activeTab === "exam-forms" && <ExamForms />}
-          {activeTab === "scholarships" && <Scholarships />}
-          {activeTab === "bus-routes" && <BusRoutes />}
-          {activeTab === "exam-halls" && <ExamHalls />}
-          {activeTab === "hall-allocation" && <HallAllocation />}
-          {activeTab === "audit-logs" && <AuditLogs />}
-          {activeTab === "manage-bookings" && <BookingManagement />}
-          {activeTab === "manage-resources" && <ResourceManagement />}
-        </>
-      );
-    };
-
-    if (loading) {
-      return (
-        <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center">
-          <div className="text-center">
-            <div className="inline-block animate-spin rounded-full h-8 w-8 border-2 border-blue-600 border-t-transparent" />
-            <p className="mt-4 text-gray-600 dark:text-gray-400">Loading dashboard...</p>
+                </div>
+              );
+            })}
           </div>
         </div>
       );
     }
 
+    const placeholders: Partial<Record<TabType, string>> = {
+      classes: "Class management is not connected on this dashboard yet.",
+      syllabus: "Syllabus management is not connected on this dashboard yet.",
+      fees: "Fee management is not connected on this dashboard yet.",
+      examSchedule: "Use the exam schedule route to manage exam schedules.",
+      events: "Event management is not connected on this dashboard yet.",
+    };
+
+    if (placeholders[activeTab]) {
+      return <div className="text-sm text-gray-600 dark:text-gray-300">{placeholders[activeTab]}</div>;
+    }
+
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex">
-        {sidebarOpen && (
-          <div className="fixed inset-0 bg-gray-900/50 z-40 lg:hidden" onClick={() => setSidebarOpen(false)} />
-        )}
-
-        <aside className={`fixed lg:static inset-y-0 left-0 z-50 w-72 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out ${sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"}`}>
-          <div className="flex flex-col h-full">
-            <div className="p-6 border-b border-gray-200 dark:border-gray-700">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h2 className="text-xl font-bold text-gray-900 dark:text-white">HOD Portal</h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{profileDepartment}</p>
-                </div>
-                <button onClick={() => setSidebarOpen(false)} className="lg:hidden p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
-                  <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
-                </button>
-              </div>
-            </div>
-
-            <nav className="flex-1 overflow-y-auto p-4">
-              <div className="space-y-1">
-                {navigationItems.map((item) => {
-                  const Icon = item.icon;
-                  const isActive = activeTab === item.id;
-                  return (
-                    <button
-                      key={item.id}
-                      onClick={() => {
-                        if (item.id === ("reports" as TabType)) {
-                          navigate("/hod/reports");
-                        }
-                      }}
-                      className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-colors ${isActive ? "bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400" : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"}`}
-                    >
-                      <Icon className={`w-5 h-5 ${isActive ? "text-blue-600" : "text-gray-500 dark:text-gray-400"}`} />
-                      <span>{item.label}</span>
-                      {isActive && <ChevronRight className="w-4 h-4 ml-auto text-blue-600" />}
-                    </button>
-                  );
-                })}
-              </div>
-            </nav>
-
-            <div className="p-4 border-t border-gray-200 dark:border-gray-700">
-              <button onClick={() => setActiveTab("settings")} className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
-                <Settings className="w-4 h-4 text-gray-500 dark:text-gray-400" /> Settings
-              </button>
-              <button onClick={handleSignOut} className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
-                <LogOut className="w-4 h-4 text-gray-500 dark:text-gray-400" /> Sign Out
-              </button>
-            </div>
+      <>
+        {activeTab === "announcements" && (
+          <div className="space-y-8">
+            <AnnouncementForm />
+            <hr className="border-gray-200 dark:border-gray-700" />
+            <AnnouncementManage />
           </div>
-        </aside>
+        )}
+        {activeTab === "teachers" && <Teachers />}
+        {activeTab === "teachers-attendance" && <HODTeacherAttendance />}
+        {activeTab === "students" && <Students />}
+        {activeTab === "salary" && <HODSalary />}
+        {activeTab === "academic-calendar" && <AcademicCalendar role="hod" />}
+        {activeTab === "library" && <Library />}
+        {activeTab === "courses" && <HODCourses />}
+        {activeTab === "settings" && <HODSettings />}
+        {activeTab === "feedback" && <FeedbackManagement />}
+        {activeTab === "exam-forms" && <ExamForms />}
+        {activeTab === "scholarships" && <Scholarships />}
+        {activeTab === "bus-routes" && <BusRoutes />}
+        {activeTab === "exam-halls" && <ExamHalls />}
+        {activeTab === "hall-allocation" && <HallAllocation />}
+        {activeTab === "audit-logs" && <AuditLogs />}
+        {activeTab === "manage-bookings" && <BookingManagement />}
+        {activeTab === "manage-resources" && <ResourceManagement />}
+        {activeTab === "faculty-assignment" && <FacultyAssignment />}
+      </>
+    );
+  };
 
-        <div className="flex-1 min-w-0">
-          <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-30">
-            <div className="px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <button onClick={() => setSidebarOpen(true)} className="lg:hidden p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
-                  <Menu className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-                </button>
-                <div className="relative hidden sm:block w-80">
-                  <Search className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2" />
-                  <input
-                    type="text"
-                    placeholder="Search students, teachers, courses..."
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-9 pr-4 py-2 border border-gray-200 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
-                  />
-                  {searchTerm && (
-                    <div className="absolute top-full mt-2 w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 max-h-80 overflow-y-auto">
-                      {(["students", "teachers", "courses"] as const).map((group) => (
-                        <div key={group} className="p-2">
-                          <h4 className="font-bold text-blue-600 capitalize">{group}</h4>
-                          {searchResults[group].map((item: any) => (
-                            <div key={item._id} className="p-2 border-b border-gray-100 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-200">
-                              {item.name || item.email || item.code}
-                            </div>
-                          ))}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex items-center gap-3">
-                <button onClick={toggleTheme} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
-                  {darkMode ? <Sun className="w-5 h-5 text-gray-300" /> : <Moon className="w-5 h-5 text-gray-600" />}
-                </button>
-               <button
-                  onClick={() => navigate("/announcements")}
-                  className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg relative"
-                >
-                  <Bell className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-                </button>
-                <div className="w-8 h-8 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-xs font-semibold">
-                  {profileInitials || "H"}
-                </div>
-                <button onClick={fetchDashboardData} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg" title="Refresh">
-                  <RefreshCw className="w-4 h-4 text-gray-600 dark:text-gray-300" />
-                </button>
-              </div>
-            </div>
-          </header>
-
-          <main className="p-4 sm:p-6 lg:p-8">
-            <div className="mb-8">
-              <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">{activeLabel}</h1>
-              <p className="text-gray-500 dark:text-gray-400 mt-1">
-                {activeTab === "overview" ? "Welcome back. Here's what's happening with your department today." : `Manage ${activeLabel.toLowerCase()}.`}
-              </p>
-            </div>
-            {renderTab()}
-          </main>
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-8 w-8 border-2 border-blue-600 border-t-transparent" />
+          <p className="mt-4 text-gray-600 dark:text-gray-400">Loading dashboard...</p>
         </div>
       </div>
     );
   }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex">
+      {sidebarOpen && (
+        <div className="fixed inset-0 bg-gray-900/50 z-40 lg:hidden" onClick={() => setSidebarOpen(false)} />
+      )}
+
+      <aside className={`fixed lg:static inset-y-0 left-0 z-50 w-72 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-300 ease-in-out ${sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"}`}>
+        <div className="flex flex-col h-full">
+          <div className="p-6 border-b border-gray-200 dark:border-gray-700">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">HOD Portal</h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{profileDepartment}</p>
+              </div>
+              <button onClick={() => setSidebarOpen(false)} className="lg:hidden p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+                <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+              </button>
+            </div>
+          </div>
+
+          <nav className="flex-1 overflow-y-auto p-4">
+            <div className="space-y-1">
+              {navigationItems.map((item) => {
+                const Icon = item.icon;
+                const isActive = activeTab === item.id;
+                return (
+                  <button
+                    key={item.id}
+                    onClick={() => {
+                      if (item.id === ("reports" as TabType)) {
+                        navigate("/hod/reports");
+                      } else {
+                        setActiveTab(item.id);
+                      }
+                    }}
+                    className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-colors ${isActive ? "bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400" : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"}`}
+                  >
+                    <Icon className={`w-5 h-5 ${isActive ? "text-blue-600" : "text-gray-500 dark:text-gray-400"}`} />
+                    <span>{item.label}</span>
+                    {isActive && <ChevronRight className="w-4 h-4 ml-auto text-blue-600" />}
+                  </button>
+                );
+              })}
+            </div>
+          </nav>
+
+          <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+            <button onClick={() => setActiveTab("settings")} className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+              <Settings className="w-4 h-4 text-gray-500 dark:text-gray-400" /> Settings
+            </button>
+            <button onClick={handleSignOut} className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+              <LogOut className="w-4 h-4 text-gray-500 dark:text-gray-400" /> Sign Out
+            </button>
+          </div>
+        </div>
+      </aside>
+
+      <div className="flex-1 min-w-0">
+        <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-30">
+          <div className="px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button onClick={() => setSidebarOpen(true)} className="lg:hidden p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+                <Menu className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+              </button>
+              <div className="relative hidden sm:block w-80">
+                <Search className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2" />
+                <input
+                  type="text"
+                  placeholder="Search students, teachers, courses..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="pl-9 pr-4 py-2 border border-gray-200 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                />
+                {searchTerm && (
+                  <div className="absolute top-full mt-2 w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 max-h-80 overflow-y-auto">
+                    {(["students", "teachers", "courses"] as const).map((group) => (
+                      <div key={group} className="p-2">
+                        <h4 className="font-bold text-blue-600 capitalize">{group}</h4>
+                        {searchResults[group].map((item: any) => (
+                          <div key={item._id} className="p-2 border-b border-gray-100 dark:border-gray-700 text-sm text-gray-800 dark:text-gray-200">
+                            {item.name || item.email || item.code}
+                          </div>
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <button onClick={toggleTheme} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+                {darkMode ? <Sun className="w-5 h-5 text-gray-300" /> : <Moon className="w-5 h-5 text-gray-600" />}
+              </button>
+              <button
+                onClick={() => navigate("/announcements")}
+                className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg relative"
+              >
+                <Bell className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+              </button>
+              <div className="w-8 h-8 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-xs font-semibold">
+                {profileInitials || "H"}
+              </div>
+              <button onClick={fetchDashboardData} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg" title="Refresh">
+                <RefreshCw className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+              </button>
+            </div>
+          </div>
+        </header>
+
+        <main className="p-4 sm:p-6 lg:p-8">
+          <div className="mb-8">
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">{activeLabel}</h1>
+            <p className="text-gray-500 dark:text-gray-400 mt-1">
+              {activeTab === "overview" ? "Welcome back. Here's what's happening with your department today." : `Manage ${activeLabel.toLowerCase()}.`}
+            </p>
+          </div>
+          {renderTab()}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/collegems-client/src/pages/ParentDashboard.tsx
+++ b/collegems-client/src/pages/ParentDashboard.tsx
@@ -28,7 +28,10 @@ import Fees from "../user-components/Fee";
 import StudentResults from "../user-components/StudentResults";
 import EventsStudent from "../user-components/EventsStudent";
 import AnnouncementsView from "../user-components/AnnouncementsView";
-
+// Add these at the top of your file
+import { formatDistanceToNow } from "date-fns";
+import { useNotifications } from "../hooks/useNotifications";
+import NotificationBell from "../common-components-management/NotificationBell"; // Adjust path if needed
 
 type TabType =
   | "overview"
@@ -340,7 +343,7 @@ export default function ParentDashboard() {
           {/* Warnings Section */}
           {notifications.length > 0 && (
             <div className="mb-8 space-y-4">
-              {notifications.map((notif) => (
+             {notifications.map((notif: any) => (
                 <div 
                   key={notif._id} 
                   onClick={() => !notif.isRead && markAsRead(notif._id)}

--- a/collegems-client/src/pages/StudentDashboard.tsx
+++ b/collegems-client/src/pages/StudentDashboard.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Users } from "lucide-react";
 import {
   AwardIcon,
   Bell,
@@ -32,10 +31,16 @@ import {
 } from "lucide-react";
 import { useTheme } from "../context/ThemeContext";
 import api from "../api/axios";
+
+// Common Components
 import AcademicCalendar from "../common-components-management/AcademicCalendar";
 import AssignmentReminder from "../common-components-management/AssignmentReminder";
 import BusRoutes from "../common-components-management/BusRoutes";
 import Library from "../common-components-management/Library";
+import Scholarships from "../common-components-management/Scholarships";
+import Teachers from "../hod-components/Teachers";
+
+// Student Components
 import Assignment from "../user-components/Assignment";
 import Attendance from "../user-components/Attendance";
 import Courses from "../user-components/Courses";
@@ -48,18 +53,12 @@ import LeaveRequest from "../user-components/LeaveRequest";
 import StudentAchievements from "../user-components/StudentAchievements";
 import ProfileCompletionCard from "../user-components/ProfileCompletionCard";
 import PlacementEligibility from "../user-components/PlacementEligibility";
-
-import Scholarships from "../common-components-management/Scholarships";
-// import IDCard from "../user-components/IDCard";
-import Teachers from "../hod-components/Teachers";
-
-import ProfileCompletionCard from "../user-components/ProfileCompletionCard";
 import StudentResults from "../user-components/StudentResults";
 import StudentSeatView from "../user-components/StudentSeatView";
 import UpcomingExamsWidget from "../user-components/UpcomingExamWidget";
-import ProfileCompletionCard from "../user-components/ProfileCompletionCard";
 import ResourceBooking from "../user-components/ResourceBooking";
 import AnnouncementsView from "../user-components/AnnouncementsView";
+// import IDCard from "../user-components/IDCard";
 
 type TabType =
   | "overview"
@@ -83,8 +82,6 @@ type TabType =
   | "id-card"
   | "feedback"
   | "bus-routes"
-  | "settings"
-  | "faculty"
   | "book-resources"
   | "settings";
 
@@ -105,11 +102,10 @@ const navigationItems = [
   { id: "library" as TabType, label: "Library", icon: BookOpen },
   { id: "exam-form" as TabType, label: "Examination Form", icon: FileText },
   { id: "scholarships" as TabType, label: "Scholarships", icon: AwardIcon },
-  //{ id: "id-card" as TabType, label: "ID Card", icon: IdCard },
+  // { id: "id-card" as TabType, label: "ID Card", icon: IdCard },
   { id: "feedback" as TabType, label: "Feedback", icon: MessageSquare },
   { id: "placement" as TabType, label: "Placement", icon: Briefcase },
   { id: "bus-routes" as TabType, label: "Bus Tracking", icon: Bus },
-  { id: "faculty" as TabType, label: "Subject Faculty", icon: GraduationCap },
   { id: "book-resources" as TabType, label: "Book Resources", icon: CalendarDays },
 ];
 
@@ -119,14 +115,14 @@ export default function StudentDashboard() {
   const [data, setData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [profileData, setProfileData] = useState<any>(null);
-  const [activeTab, setActiveTab] = useState("overview");
+  const [activeTab, setActiveTab] = useState<TabType>("overview");
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [, setShowScheduleModal] = useState(false);
 
   useEffect(() => {
     fetchDashboardData();
+    fetchProfile();
   }, []);
-    useEffect(() => {
+
   const fetchProfile = async () => {
     try {
       const res = await api.get("/users/me");
@@ -135,9 +131,6 @@ export default function StudentDashboard() {
       console.error("Profile fetch error:", err);
     }
   };
-  fetchProfile();
-}, []);
- 
 
   const fetchDashboardData = async () => {
     try {
@@ -170,11 +163,11 @@ export default function StudentDashboard() {
     return "Good evening";
   };
 
-
   const renderTab = () => {
     if (activeTab === "overview") {
       return (
         <div className="space-y-8">
+          {/* Notifications Alerts */}
           {data?.notifications && data.notifications.length > 0 && (
             <div className="space-y-4">
               {data.notifications.map((notif: any, idx: number) => (
@@ -188,38 +181,183 @@ export default function StudentDashboard() {
               ))}
             </div>
           )}
+
+          {/* Profile Completion */}
+          {profileData?.profileCompletion && (
+            <ProfileCompletionCard
+              percentage={profileData.profileCompletion.percentage}
+              missingFields={profileData.profileCompletion.missingFields}
+            />
+          )}
+
+          {/* Stats Grid */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
             {[
-              { title: "Attendance", value: data?.cards?.find((c: any) => c.title === "Attendance")?.value || "0%", icon: CalendarCheck, color: "bg-blue-50 text-blue-700" },
-              { title: "Pending Assignments", value: data?.cards?.find((c: any) => c.title === "Pending Assignments")?.value || "0", icon: FileText, color: "bg-amber-50 text-amber-700" },
-              { title: "Fee Due", value: `Rs ${data?.cards?.find((c: any) => c.title === "Fee Due")?.value || "0"}`, icon: Wallet, color: "bg-emerald-50 text-emerald-700" },
-              { title: "Courses", value: "Active", icon: BookOpen, color: "bg-purple-50 text-purple-700" },
-            ].map((stat) => {
+              {
+                title: "Attendance",
+                value: data?.cards?.find((c: any) => c.title === "Attendance")?.value || "0%",
+                icon: CalendarCheck,
+                color: "blue",
+                trend: "Overall",
+              },
+              {
+                title: "Pending Assignments",
+                value: data?.cards?.find((c: any) => c.title === "Pending Assignments")?.value || "0",
+                icon: FileText,
+                color: "amber",
+                trend: "Current",
+              },
+              {
+                title: "Fee Due",
+                value: "₹" + (data?.cards?.find((c: any) => c.title === "Fee Due")?.value || "0"),
+                icon: Wallet,
+                color: "emerald",
+                trend: "Total",
+              },
+              {
+                title: "Courses",
+                value: "Active",
+                icon: BookOpen,
+                color: "purple",
+                trend: "Active",
+              },
+            ].map((stat, index) => {
               const Icon = stat.icon;
+              const colorClasses = {
+                blue: "bg-blue-50 text-blue-700",
+                amber: "bg-amber-50 text-amber-700",
+                emerald: "bg-emerald-50 text-emerald-700",
+                purple: "bg-purple-50 text-purple-700",
+              }[stat.color as string];
+
               return (
-                <div key={stat.title} className="bg-white rounded-xl border border-gray-200 p-6">
+                <div key={index} className="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-shadow">
                   <div className="flex items-start justify-between">
                     <div>
                       <p className="text-sm text-gray-500 mb-1">{stat.title}</p>
                       <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
                     </div>
-                    <div className={`p-3 rounded-lg ${stat.color}`}>
+                    <div className={`p-3 rounded-lg ${colorClasses}`}>
                       <Icon className="w-5 h-5" />
                     </div>
+                  </div>
+                  <div className="mt-4 flex items-center gap-1 text-sm">
+                    <TrendingUp className={`w-4 h-4 ${stat.title === "Fee Due" && stat.value !== "₹0" ? "text-amber-600" : "text-green-600"}`} />
+                    <span className={`font-medium ${stat.title === "Fee Due" && stat.value !== "₹0" ? "text-amber-600" : "text-green-600"}`}>
+                      {stat.trend}
+                    </span>
+                    <span className="text-gray-500 ml-1">status</span>
                   </div>
                 </div>
               );
             })}
           </div>
+
           <AssignmentReminder />
+
+          {/* Quick Actions */}
+          <div className="bg-white rounded-xl border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {[
+                {
+                  label: "Submit Assignment",
+                  description: "You have pending assignments",
+                  icon: FileText,
+                  color: "blue",
+                  onClick: () => setActiveTab("assignments"),
+                },
+                {
+                  label: "Pay Fees",
+                  description: "Check pending fee amounts",
+                  icon: Wallet,
+                  color: "amber",
+                  onClick: () => setActiveTab("fees"),
+                },
+                {
+                  label: "Submit Feedback",
+                  description: "Share your thoughts on courses",
+                  icon: MessageSquare,
+                  color: "emerald",
+                  onClick: () => setActiveTab("feedback"),
+                },
+              ].map((action, index) => {
+                const Icon = action.icon;
+                const colorClasses = {
+                  blue: "bg-blue-50 text-blue-700 hover:bg-blue-100",
+                  amber: "bg-amber-50 text-amber-700 hover:bg-amber-100",
+                  emerald: "bg-emerald-50 text-emerald-700 hover:bg-emerald-100",
+                }[action.color];
+
+                return (
+                  <button key={index} onClick={action.onClick} className={`flex items-start gap-4 p-4 rounded-lg border border-gray-200 transition-colors text-left ${colorClasses}`}>
+                    <div className="p-2 rounded-lg bg-white">
+                      <Icon className="w-5 h-5" />
+                    </div>
+                    <div>
+                      <p className="font-medium text-gray-900">{action.label}</p>
+                      <p className="text-sm text-gray-500 mt-1">{action.description}</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Today's Schedule */}
+          <div className="bg-white rounded-xl border border-gray-200 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900">Today's Schedule</h2>
+              <button onClick={() => setActiveTab("courses")} className="text-sm text-blue-600 hover:text-blue-700 font-medium">
+                View all
+              </button>
+            </div>
+            <div className="space-y-4">
+              {data?.todayClasses && data.todayClasses.length > 0 ? (
+                data.todayClasses.slice(0, 3).map((class_: any, index: number) => {
+                  const parseTime = (timeStr: string) => {
+                    const [time, modifier] = timeStr.split(" ");
+                    let [hours, minutes] = time.split(":");
+                    if (hours === "12") hours = "00";
+                    if (modifier.toUpperCase() === "PM") hours = String(parseInt(hours, 10) + 12);
+                    return parseInt(hours, 10) * 60 + parseInt(minutes, 10);
+                  };
+                  const now = new Date();
+                  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+                  const isUpcoming = data.todayClasses.findIndex((c: any) => parseTime(c.time) >= currentMinutes) === index;
+
+                  return (
+                    <div key={class_.id || index} className={`flex items-center gap-4 p-4 rounded-lg transition-colors ${isUpcoming ? "bg-blue-50 border border-blue-200 shadow-sm" : "bg-gray-50 border border-transparent"}`}>
+                      <div className={`w-16 text-sm font-medium ${isUpcoming ? "text-blue-700" : "text-gray-700"}`}>{class_.time}</div>
+                      <div className="flex-1">
+                        <p className={`font-medium ${isUpcoming ? "text-blue-900" : "text-gray-900"}`}>{class_.subject}</p>
+                        <p className={`text-sm ${isUpcoming ? "text-blue-600" : "text-gray-500"}`}>{class_.faculty} • {class_.room} • {class_.type}</p>
+                      </div>
+                      {isUpcoming && <span className="px-2.5 py-1 text-xs font-semibold bg-blue-100 text-blue-700 rounded-full animate-pulse">Next</span>}
+                    </div>
+                  );
+                })
+              ) : (
+                <div className="py-6 text-center text-gray-500">
+                  <Calendar className="w-8 h-8 mx-auto mb-2 text-gray-400" />
+                  <p>No classes scheduled for today.</p>
+                </div>
+              )}
+            </div>
+          </div>
+
           <UpcomingExamsWidget />
           <StudentAchievements />
         </div>
       );
     }
 
+    // Other Tabs Logic
+    const fullWidthTabs = ["leave", "achievements", "my-seat"];
+    const containerClass = fullWidthTabs.includes(activeTab) ? "" : "bg-white rounded-xl border border-gray-200 p-6";
+
     return (
-      <div className={activeTab === "leave" || activeTab === "achievements" || activeTab === "my-seat" ? "" : "bg-white rounded-xl border border-gray-200 p-6"}>
+      <div className={containerClass}>
         {activeTab === "attendance" && <Attendance />}
         {activeTab === "assignments" && <Assignment />}
         {activeTab === "fees" && <Fees />}
@@ -236,12 +374,11 @@ export default function StudentDashboard() {
         {activeTab === "exam-form" && <ExaminationForm />}
         {activeTab === "feedback" && <StudentFeedback />}
         {activeTab === "bus-routes" && <BusRoutes />}
-        {activeTab === "faculty" && <FacultyView />}
+        {activeTab === "faculty" && <Teachers />}
         {activeTab === "book-resources" && <ResourceBooking />}
         {activeTab === "placement" && <PlacementEligibility />}
         {activeTab === "scholarships" && <Scholarships />}
-        {activeTab === "id-card" && <IDCard student={student} />}
-        {activeTab === "faculty" && <Teachers />}
+        {/* {activeTab === "id-card" && <IDCard student={student} />} */}
         {activeTab === "settings" && <div className="text-sm text-gray-600">Settings are not available yet for student accounts.</div>}
       </div>
     );
@@ -262,7 +399,7 @@ export default function StudentDashboard() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center max-w-md mx-auto px-4">
-          <Bell className="w-12 h-12 text-red-600 mx-auto mb-4" />
+          <AlertCircle className="w-12 h-12 text-red-600 mx-auto mb-4" />
           <h3 className="text-xl font-semibold text-gray-900 mb-2">Unable to load dashboard</h3>
           <p className="text-gray-600 mb-6">There was an error loading your dashboard. Please try again.</p>
           <button onClick={fetchDashboardData} className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
@@ -345,7 +482,10 @@ export default function StudentDashboard() {
               <button onClick={toggleTheme} className="p-2 hover:bg-gray-100 rounded-lg">
                 {darkMode ? <Sun className="w-5 h-5 text-gray-600" /> : <Moon className="w-5 h-5 text-gray-600" />}
               </button>
-              <NotificationBell />
+              <button onClick={() => setActiveTab("announcements")} className="p-2 hover:bg-gray-100 rounded-lg relative">
+                <Bell className="w-5 h-5 text-gray-600" />
+                {data?.notifications?.length > 0 && <span className="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full" />}
+              </button>
             </div>
           </div>
         </header>
@@ -358,248 +498,8 @@ export default function StudentDashboard() {
             <p className="text-gray-500 mt-1">Here's what's happening with your academic progress.</p>
           </div>
 
-          {/* Content Area */}
-          {activeTab === "overview" ? (
-            <div className="space-y-8">
-              {/* Profile Completion */}
-              {profileData?.profileCompletion && (
-                <ProfileCompletionCard
-                  percentage={profileData.profileCompletion.percentage}
-                  missingFields={profileData.profileCompletion.missingFields}
-                />
-              )}
-
-              {/* Stats Grid */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                {[
-                  {
-                    title: "Attendance",
-                    value: data?.cards?.find((c: any) => c.title === "Attendance")?.value || "0%",
-                    icon: CalendarCheck,
-                    color: "blue",
-                    trend: "Overall",
-                  },
-                  {
-                    title: "Pending Assignments",
-                    value: data?.cards?.find((c: any) => c.title === "Pending Assignments")?.value || "0",
-                    icon: FileText,
-                    color: "amber",
-                    trend: "Current",
-                  },
-                  {
-                    title: "Fee Due",
-                    value: "₹" + (data?.cards?.find((c: any) => c.title === "Fee Due")?.value || "0"),
-                    icon: Wallet,
-                    color: "emerald",
-                    trend: "Total",
-                  },
-                  {
-                    title: "Courses",
-                    value: "Active",
-                    icon: BookOpen,
-                    color: "purple",
-                    trend: "Active",
-                  },
-                ].map((stat, index) => {
-                  const Icon = stat.icon;
-                  const colorClasses = {
-                    blue: "bg-blue-50 text-blue-700",
-                    amber: "bg-amber-50 text-amber-700",
-                    emerald: "bg-emerald-50 text-emerald-700",
-                    purple: "bg-purple-50 text-purple-700",
-                  }[stat.color];
-
-                  return (
-                    <div
-                      key={index}
-                      className="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-shadow"
-                    >
-                      <div className="flex items-start justify-between">
-                        <div>
-                          <p className="text-sm text-gray-500 mb-1">{stat.title}</p>
-                          <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
-                        </div>
-                        <div className={`p-3 rounded-lg ${colorClasses}`}>
-                          <Icon className="w-5 h-5" />
-                        </div>
-                      </div>
-                      <div className="mt-4 flex items-center gap-1 text-sm">
-                        <TrendingUp
-                          className={`w-4 h-4 ${
-                            stat.title === "Fee Due" && stat.value !== "₹0"
-                              ? "text-amber-600"
-                              : "text-green-600"
-                          }`}
-                        />
-                        <span
-                          className={`font-medium ${
-                            stat.title === "Fee Due" && stat.value !== "₹0"
-                              ? "text-amber-600"
-                              : "text-green-600"
-                          }`}
-                        >
-                          {stat.trend}
-                        </span>
-                        <span className="text-gray-500 ml-1">status</span>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* Assignment Reminders widget */}
-              <AssignmentReminder />
-
-              {/* Quick Actions */}
-              <div className="bg-white rounded-xl border border-gray-200 p-6">
-                <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {[
-                    {
-                      label: "Submit Assignment",
-                      description: "You have 2 pending assignments",
-                      icon: FileText,
-                      color: "blue",
-                      onClick: () => setActiveTab("assignments"),
-                    },
-                    {
-                      label: "Pay Fees",
-                      description: "Due date: March 15, 2024",
-                      icon: Wallet,
-                      color: "amber",
-                      onClick: () => setActiveTab("fees"),
-                    },
-                    {
-                      label: "Submit Feedback",
-                      description: "Share your thoughts on courses and campus",
-                      icon: MessageSquare,
-                      color: "emerald",
-                      onClick: () => setActiveTab("feedback"),
-                    },
-                  ].map((action, index) => {
-                    const Icon = action.icon;
-                    const colorClasses = {
-                      blue: "bg-blue-50 text-blue-700 hover:bg-blue-100",
-                      amber: "bg-amber-50 text-amber-700 hover:bg-amber-100",
-                      emerald: "bg-emerald-50 text-emerald-700 hover:bg-emerald-100",
-                    }[action.color];
-
-                    return (
-                      <button
-                        key={index}
-                        onClick={action.onClick}
-                        className={`flex items-start gap-4 p-4 rounded-lg border border-gray-200
-                          transition-colors text-left ${colorClasses}`}
-                      >
-                        <div className="p-2 rounded-lg bg-white">
-                          <Icon className="w-5 h-5" />
-                        </div>
-                        <div>
-                          <p className="font-medium text-gray-900">{action.label}</p>
-                          <p className="text-sm text-gray-500 mt-1">{action.description}</p>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Today's Schedule */}
-              <div className="bg-white rounded-xl border border-gray-200 p-6">
-                <div className="flex items-center justify-between mb-4">
-                  <h2 className="text-lg font-semibold text-gray-900">Today's Schedule</h2>
-                  <button
-                    onClick={() => {}}
-                    className="text-sm text-blue-600 hover:text-blue-700 font-medium"
-                  >
-                    View all
-                  </button>
-                </div>
-                <div className="space-y-4">
-                  {data?.todayClasses && data.todayClasses.length > 0 ? (
-                    data.todayClasses.slice(0, 3).map((class_: any, index: number) => {
-                      const parseTime = (timeStr: string) => {
-                        const [time, modifier] = timeStr.split(" ");
-                        let [hours, minutes] = time.split(":");
-                        if (hours === "12") hours = "00";
-                        if (modifier.toUpperCase() === "PM")
-                          hours = String(parseInt(hours, 10) + 12);
-                        return parseInt(hours, 10) * 60 + parseInt(minutes, 10);
-                      };
-                      const now = new Date();
-                      const currentMinutes = now.getHours() * 60 + now.getMinutes();
-                      const isUpcoming =
-                        data.todayClasses.findIndex(
-                          (c: any) => parseTime(c.time) >= currentMinutes
-                        ) === index;
-
-                      return (
-                        <div
-                          key={class_.id || index}
-                          className={`flex items-center gap-4 p-4 rounded-lg transition-colors ${
-                            isUpcoming
-                              ? "bg-blue-50 border border-blue-200 shadow-sm"
-                              : "bg-gray-50 border border-transparent"
-                          }`}
-                        >
-                          <div className={`w-16 text-sm font-medium ${isUpcoming ? "text-blue-700" : "text-gray-700"}`}>
-                            {class_.time}
-                          </div>
-                          <div className="flex-1">
-                            <p className={`font-medium ${isUpcoming ? "text-blue-900" : "text-gray-900"}`}>
-                              {class_.subject}
-                            </p>
-                            <p className={`text-sm ${isUpcoming ? "text-blue-600" : "text-gray-500"}`}>
-                              {class_.faculty} • {class_.room} • {class_.type}
-                            </p>
-                          </div>
-                          {isUpcoming && (
-                            <span className="px-2.5 py-1 text-xs font-semibold bg-blue-100 text-blue-700 rounded-full animate-pulse">
-                              Next
-                            </span>
-                          )}
-                        </div>
-                      );
-                    })
-                  ) : (
-                    <div className="py-6 text-center text-gray-500">
-                      <Calendar className="w-8 h-8 mx-auto mb-2 text-gray-400" />
-                      <p>No classes scheduled for today.</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-        <UpcomingExamsWidget />
-          <StudentAchievements />
-            </div>
-          ) : (
-            <div className={activeTab === "leave" || activeTab === "achievements" ? "" : "bg-white rounded-xl border border-gray-200 p-6"}>
-              {activeTab === "attendance" && <Attendance />}
-              {activeTab === "assignments" && <Assignment />}
-              {activeTab === "fees" && <Fees />}
-              {activeTab === "courses" && <Courses />}
-              {activeTab === "examschedule" && <ExamSchedule />}
-              {activeTab === "academic-calendar" && <AcademicCalendar role="student" />}
-              {activeTab === "events" && <EventsStudent />}
-              
-              {activeTab === "results" && <StudentResults />}
-              {activeTab === "achievements" && <StudentAchievements />}
-              {activeTab === "leave" && <LeaveRequest />}
-              {activeTab === "library" && <Library />}
-              {activeTab === "exam-form" && <ExaminationForm />}
-              
-              {activeTab === "feedback" && <StudentFeedback />}
-
-              {activeTab === "bus-routes" && <BusRoutes />}
-              {activeTab === "book-resources" && <ResourceBooking />}
-              {activeTab === "settings"          && (
-                <div className="text-sm text-gray-600">
-                  Settings are not available yet for student accounts.
-                </div>
-              )}
-            </div>
-          )}
+          {/* Render Tab Content */}
+          {renderTab()}
 
           {/* Footer */}
           <footer className="mt-8 pt-6 border-t border-gray-200">

--- a/collegems-client/src/pages/StudentDashboard.tsx
+++ b/collegems-client/src/pages/StudentDashboard.tsx
@@ -39,7 +39,7 @@ import BusRoutes from "../common-components-management/BusRoutes";
 import Library from "../common-components-management/Library";
 import Scholarships from "../common-components-management/Scholarships";
 import Teachers from "../hod-components/Teachers";
-
+import Clubs from "../common-components-management/Clubs";
 // Student Components
 import Assignment from "../user-components/Assignment";
 import Attendance from "../user-components/Attendance";
@@ -83,7 +83,8 @@ type TabType =
   | "feedback"
   | "bus-routes"
   | "book-resources"
-  | "settings";
+  | "settings" 
+  |  "clubs";
 
 const navigationItems = [
   { id: "overview" as TabType, label: "Overview", icon: LayoutGrid },
@@ -107,6 +108,7 @@ const navigationItems = [
   { id: "placement" as TabType, label: "Placement", icon: Briefcase },
   { id: "bus-routes" as TabType, label: "Bus Tracking", icon: Bus },
   { id: "book-resources" as TabType, label: "Book Resources", icon: CalendarDays },
+  { id: "clubs" as TabType, label: "Clubs & Organizations", icon: Users },
 ];
 
 export default function StudentDashboard() {
@@ -378,6 +380,7 @@ export default function StudentDashboard() {
         {activeTab === "book-resources" && <ResourceBooking />}
         {activeTab === "placement" && <PlacementEligibility />}
         {activeTab === "scholarships" && <Scholarships />}
+        {activeTab === "clubs" && <Clubs />}
         {/* {activeTab === "id-card" && <IDCard student={student} />} */}
         {activeTab === "settings" && <div className="text-sm text-gray-600">Settings are not available yet for student accounts.</div>}
       </div>

--- a/collegems-client/src/pages/TeacherDashboard.tsx
+++ b/collegems-client/src/pages/TeacherDashboard.tsx
@@ -33,7 +33,7 @@ import OfficeHours from "../teacher-components/OfficeHours";
 import ResourceBooking from "../user-components/ResourceBooking";
 import AnnouncementForm from "../common-components-management/AnnouncementForm";
 import AnnouncementManage from "../common-components-management/AnnouncementManage";
-
+import Clubs from "../common-components-management/Clubs";
 interface TeacherDashboardProps {
   initialTab?: string;
 }
@@ -116,6 +116,7 @@ const [activeTab, setActiveTab] = useState(initialTab ?? "overview");
     { id: "events", label: "Organize Events", icon: CalendarDays },
     { id: "library", label: "Library Catalog", icon: Book },
     { id: "book-resources", label: "Book Resources", icon: CalendarDays },
+    { id: "clubs", label: "Clubs & Organizations", icon: Users },
   ];
 
   const activeTabLabel = activeTab === "settings" ? "Settings"
@@ -388,6 +389,7 @@ const [activeTab, setActiveTab] = useState(initialTab ?? "overview");
           {activeTab === "library" && <Library />}
           {activeTab === "my-assignments" && <MyAssignments />}
           {activeTab === "book-resources" && <ResourceBooking />}
+          {activeTab === "clubs" && <Clubs />}
           {activeTab === "announcements" && (
             <div className="space-y-8">
               <AnnouncementForm />

--- a/collegems-client/src/pages/TeacherDashboard.tsx
+++ b/collegems-client/src/pages/TeacherDashboard.tsx
@@ -45,8 +45,9 @@ export default function TeacherDashboard({ initialTab }: TeacherDashboardProps) 
   const [courses, setCourses] = useState<{ _id: string; name: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState(initialTab ?? "overview");
+const [activeTab, setActiveTab] = useState(initialTab ?? "overview");
   const [upcomingClasses, setUpcomingClasses] = useState<any[]>([]);
+  const [notifications, setNotifications] = useState<any[]>([]);
 
   const handleSignOut = () => {
     localStorage.removeItem("token");
@@ -60,12 +61,25 @@ export default function TeacherDashboard({ initialTab }: TeacherDashboardProps) 
   const fetchDashboardData = async () => {
     try {
       setLoading(true);
-      const [dashboardRes, coursesRes] = await Promise.all([
+     const [dashboardRes, coursesRes] = await Promise.all([
         api.get("/dashboard"),
         api.get("/courses/all"),
       ]);
       setData(dashboardRes.data);
-      setCourses(coursesRes.data);
+      
+      // --- NEW SAFTEY CHECK FOR COURSES ---
+      const fetchedCourses = coursesRes.data;
+      if (Array.isArray(fetchedCourses)) {
+        setCourses(fetchedCourses);
+      } else if (fetchedCourses && Array.isArray(fetchedCourses.data)) {
+        setCourses(fetchedCourses.data);
+      } else if (fetchedCourses && Array.isArray(fetchedCourses.courses)) {
+        setCourses(fetchedCourses.courses);
+      } else {
+        setCourses([]); // Fallback to an empty array to prevent crashes
+      }
+      // ------------------------------------
+
       setUpcomingClasses([
         { id: 1, course: "Mathematics 101", time: "10:00 AM", room: "Room 301", status: "upcoming", students: 28 },
         { id: 2, course: "Physics 201", time: "2:00 PM", room: "Lab 204", status: "upcoming", students: 24 },

--- a/collegems-server/src/app.js
+++ b/collegems-server/src/app.js
@@ -20,7 +20,7 @@ import eventRoute from "./routes/event.routes.js";
 import resultsRoutes from "./routes/results.routes.js";
 import libraryRoutes from "./routes/library.routes.js";
 import assessmentRoutes from "./routes/assessment.routes.js";
-
+import clubRoutes from "./routes/clubs.routes.js";
 import courseRoutes from "./routes/course.routes.js";
 import salaryRoutes from "./routes/salary.route.js";
 import academicCalendarRoutes from "./routes/academicCalendar.routes.js";
@@ -76,7 +76,7 @@ app.use("/api/events",            eventRoute);
 app.use("/api/results",           authenticate, resultsRoutes);
 app.use("/api/library",           libraryRoutes);
 app.use("/api/assessments", authenticate, assessmentRoutes);
-
+app.use("/api/clubs", authenticate, clubRoutes);
 app.use("/api/resources", authenticate, resourceRoutes);
 app.use("/api/bookings", authenticate, bookingRoutes);
 app.use("/api/mentorships", authenticate, mentorshipRoutes);

--- a/collegems-server/src/app.js
+++ b/collegems-server/src/app.js
@@ -1,6 +1,4 @@
 // FILE: collegems-server/src/app.js
-// WHAT CHANGED: added 2 lines for feedback routes (marked ← NEW)
-// Everything else is identical to your original file.
 
 import express from "express";
 import cors from "cors";
@@ -22,20 +20,19 @@ import eventRoute from "./routes/event.routes.js";
 import resultsRoutes from "./routes/results.routes.js";
 import libraryRoutes from "./routes/library.routes.js";
 import assessmentRoutes from "./routes/assessment.routes.js";
-import mentorshipRoutes from "./routes/mentorship.routes.js";
-import complaintRoutes from "./routes/complaint.routes.js";
+
 import courseRoutes from "./routes/course.routes.js";
 import salaryRoutes from "./routes/salary.route.js";
 import academicCalendarRoutes from "./routes/academicCalendar.routes.js";
 import reportRoutes from "./routes/report.routes.js";
-import feedbackRoutes from "./routes/feedback.routes.js"; // ← NEW
-import achievementRoutes from "./routes/achievement.routes.js"; // ← NEW
+import feedbackRoutes from "./routes/feedback.routes.js"; 
+import achievementRoutes from "./routes/achievement.routes.js"; 
 import examFormRoutes from "./routes/examForm.routes.js";
 import leaveRoutes from "./routes/leave.routes.js";
 import scholarshipRoutes from "./routes/scholarship.routes.js";
 import idCardRoutes from "./routes/idcard.routes.js";
 import { verifyStudent } from "./controllers/idcard.controller.js";
-import announcementRoutes from "./routes/announcement.routes.js";  // announcement
+import announcementRoutes from "./routes/announcement.routes.js";  
 import busRouteRoutes from "./routes/busRoute.routes.js";
 import syllabusRoutes from "./routes/syllabus.route.js";
 import officeHoursRoutes from "./routes/officeHours.routes.js";
@@ -48,6 +45,10 @@ import mentorshipRoutes from "./routes/mentorship.routes.js";
 import complaintRoutes from "./routes/complaint.routes.js";
 import placementRoutes from "./routes/placement.routes.js";
 import facultyAssignmentRoutes from "./routes/facultyAssignment.routes.js";
+
+// ← NEW NOTIFICATION ROUTE IMPORT
+import notificationRoutes from "./routes/notification.routes.js"; 
+
 import { authenticate } from "./middlewares/auth.middleware.js";
 import { errorHandler } from "./middlewares/errorHandler.middleware.js";
 import log from "./utils/logger.js";
@@ -95,7 +96,7 @@ app.use("/api/syllabus", authenticate, syllabusRoutes);
 app.use("/api/reports",         reportRoutes);
 app.use("/api/feedback",        authenticate, feedbackRoutes);
 app.use("/api/placements",      authenticate, placementRoutes);
-app.use("/api/achievements",    authenticate, achievementRoutes); // ← NEW
+app.use("/api/achievements",    authenticate, achievementRoutes); 
 app.use("/api/student/idcard", idCardRoutes);
 app.get("/api/verify/student/:studentId", verifyStudent);
 app.use("/api/bus-routes", authenticate, busRouteRoutes);
@@ -104,7 +105,10 @@ app.use("/api/exam-halls", authenticate, examHallRoutes);
 app.use("/api/hall-allocations", authenticate, hallAllocationRoutes);
 app.use("/api/mentorships", mentorshipRoutes);
 app.use("/api/complaints", complaintRoutes);
-app.use("/api/announcements", announcementRoutes);  // aannouncements
+app.use("/api/announcements", announcementRoutes);  
+
+// ← NEW NOTIFICATION ROUTE REGISTRATION
+app.use("/api/notifications", authenticate, notificationRoutes);
 
 // Health check
 app.get("/", (_req, res) => {

--- a/collegems-server/src/controllers/clubs.controller.js
+++ b/collegems-server/src/controllers/clubs.controller.js
@@ -1,0 +1,487 @@
+import Club, { ROLES } from "../models/Club.model.js";
+import Event from "../models/Events.model.js";
+import mongoose from "mongoose";
+
+// FIXED: Now safely handles both Populated objects (from populateClub) and standard ObjectIds
+const isAdminOf = (club, userId) => {
+  const uId = userId.toString();
+  const creatorId = club.createdBy._id ? club.createdBy._id.toString() : club.createdBy.toString();
+  return (
+    creatorId === uId ||
+    club.admins.some((a) => (a._id ? a._id.toString() : a.toString()) === uId)
+  );
+};
+
+// FIXED: Safely handles both Populated objects and standard ObjectIds
+const isMemberOf = (club, userId) => {
+  const uId = userId.toString();
+  return club.members.some((m) => {
+    const memberUserId = m.user._id ? m.user._id.toString() : m.user.toString();
+    return memberUserId === uId;
+  });
+};
+const populateClub = (query) =>
+  query
+    .populate("createdBy", "name email role")
+    .populate("admins", "name email role")
+    .populate("members.user", "name email role teacherId studentId department")
+    .populate("pendingRequests.user", "name email role teacherId studentId department")
+    .populate("events", "title date status category")
+    .populate("announcements.postedBy", "name email"); 
+// ─── Create club ───────────────────────────────────────────────────────────────
+export const createClub = async (req, res) => {
+  try {
+    const { name, description, category, logo, maxMembers } = req.body;
+    const userId = req.user._id || req.user.id; // FIXED: fallback to ensure valid ID
+
+    if (!name || !description) {
+      return res.status(400).json({ message: "Name and description are required" });
+    }
+
+    const existing = await Club.findOne({ name });
+    if (existing) {
+      return res.status(409).json({ message: "A club with this name already exists" });
+    }
+
+    const club = await Club.create({
+      name,
+      description,
+      category,
+      logo,
+      maxMembers,
+      createdBy: userId,
+      admins: [userId],
+      members: [{ user: userId, role: "president" }],
+    });
+
+    const populated = await populateClub(Club.findById(club._id));
+    res.status(201).json(populated);
+  } catch (err) {
+    console.error("Create club error:", err);
+    res.status(500).json({ message: "Failed to create club" });
+  }
+};
+
+// ─── Get all clubs ──────────────────────────────────────────────────────────────
+export const getAllClubs = async (req, res) => {
+  try {
+    const { category, search } = req.query;
+    const filter = { isActive: true };
+    if (category) filter.category = category;
+    if (search) filter.name = { $regex: search, $options: "i" };
+
+    const clubs = await populateClub(Club.find(filter).sort({ createdAt: -1 }));
+    res.json(clubs);
+  } catch (err) {
+    console.error("Get clubs error:", err);
+    res.status(500).json({ message: "Failed to fetch clubs" });
+  }
+};
+
+// ─── Get single club ─────────────────────────────────────────────────────────────
+export const getClubById = async (req, res) => {
+  try {
+    const club = await populateClub(Club.findById(req.params.id));
+    if (!club) return res.status(404).json({ message: "Club not found" });
+    res.json(club);
+  } catch (err) {
+    console.error("Get club error:", err);
+    res.status(500).json({ message: "Failed to fetch club" });
+  }
+};
+
+// ─── Get clubs current user belongs to (member or admin) ──────────────────────────
+export const getMyClubs = async (req, res) => {
+  try {
+    const userId = req.user._id || req.user.id;
+    const clubs = await populateClub(
+      Club.find({ "members.user": userId }).sort({ createdAt: -1 })
+    );
+    res.json(clubs);
+  } catch (err) {
+    console.error("Get my clubs error:", err);
+    res.status(500).json({ message: "Failed to fetch your clubs" });
+  }
+};
+
+// ─── Update club ────────────────────────────────────────────────────────────────
+export const updateClub = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const userId = req.user._id || req.user.id;
+    
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, userId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can update club details" });
+    }
+
+    const { name, description, category, logo, maxMembers, isActive } = req.body;
+    if (name) club.name = name;
+    if (description) club.description = description;
+    if (category) club.category = category;
+    if (logo !== undefined) club.logo = logo;
+    if (maxMembers) club.maxMembers = maxMembers;
+    if (isActive !== undefined) club.isActive = isActive;
+
+    await club.save();
+    const populated = await populateClub(Club.findById(club._id));
+    res.json(populated);
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ message: "A club with this name already exists" });
+    }
+    console.error("Update club error:", err);
+    res.status(500).json({ message: "Failed to update club" });
+  }
+};
+
+// ─── Delete club ────────────────────────────────────────────────────────────────
+export const deleteClub = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const userId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, userId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can delete this club" });
+    }
+
+    await Club.findByIdAndDelete(req.params.id);
+    res.json({ message: "Club deleted successfully" });
+  } catch (err) {
+    console.error("Delete club error:", err);
+    res.status(500).json({ message: "Failed to delete club" });
+  }
+};
+
+// ─── Request to join a club ────────────────────────────────────────────────────────
+export const requestToJoin = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const userId = req.user._id || req.user.id; // FIXED: Guarantees a valid ID
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (isMemberOf(club, userId)) {
+      return res.status(409).json({ message: "You are already a member of this club" });
+    }
+
+    const alreadyRequested = club.pendingRequests.some(
+      (r) => r.user.toString() === userId.toString()
+    );
+    if (alreadyRequested) {
+      return res.status(409).json({ message: "You already have a pending request for this club" });
+    }
+
+    if (club.members.length >= club.maxMembers) {
+      return res.status(400).json({ message: "This club has reached its maximum membership limit" });
+    }
+
+    // FIXED: Push the guaranteed ID and force Mongoose to save the array
+    club.pendingRequests.push({ user: userId, message: req.body.message || "" });
+    club.markModified('pendingRequests'); 
+    await club.save();
+
+    res.status(201).json({ message: "Join request submitted successfully" });
+  } catch (err) {
+    console.error("Join request error:", err);
+    res.status(500).json({ message: "Failed to submit join request" });
+  }
+};
+
+// ─── Get pending requests (admin) ───────────────────────────────────────────────────
+export const getPendingRequests = async (req, res) => {
+  try {
+    const club = await populateClub(Club.findById(req.params.id));
+    const userId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, userId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can view join requests" });
+    }
+
+    res.json(club.pendingRequests);
+  } catch (err) {
+    console.error("Get pending requests error:", err);
+    res.status(500).json({ message: "Failed to fetch join requests" });
+  }
+};
+
+// ─── Approve a join request ──────────────────────────────────────────────────────────
+export const approveRequest = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const adminId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, adminId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can approve join requests" });
+    }
+
+    const { userId } = req.params;
+    const requestIndex = club.pendingRequests.findIndex((r) => r.user.toString() === userId);
+    if (requestIndex === -1) {
+      return res.status(404).json({ message: "Join request not found" });
+    }
+
+    if (club.members.length >= club.maxMembers) {
+      return res.status(400).json({ message: "Club has reached its maximum membership limit" });
+    }
+
+    club.pendingRequests.splice(requestIndex, 1);
+    club.members.push({ user: userId, role: "member" });
+    club.markModified('pendingRequests');
+    club.markModified('members');
+    await club.save();
+
+    const populated = await populateClub(Club.findById(club._id));
+    res.json(populated);
+  } catch (err) {
+    console.error("Approve request error:", err);
+    res.status(500).json({ message: "Failed to approve join request" });
+  }
+};
+
+// ─── Reject a join request ───────────────────────────────────────────────────────────
+export const rejectRequest = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const adminId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, adminId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can reject join requests" });
+    }
+
+    const { userId } = req.params;
+    const requestIndex = club.pendingRequests.findIndex((r) => r.user.toString() === userId);
+    if (requestIndex === -1) {
+      return res.status(404).json({ message: "Join request not found" });
+    }
+
+    club.pendingRequests.splice(requestIndex, 1);
+    club.markModified('pendingRequests');
+    await club.save();
+
+    res.json({ message: "Join request rejected" });
+  } catch (err) {
+    console.error("Reject request error:", err);
+    res.status(500).json({ message: "Failed to reject join request" });
+  }
+};
+
+// ─── Remove a member ──────────────────────────────────────────────────────────────────
+export const removeMember = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const adminId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    const { userId } = req.params;
+    const isSelf = userId === adminId.toString();
+
+    if (!isSelf && !isAdminOf(club, adminId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can remove members" });
+    }
+
+    if (userId === club.createdBy.toString()) {
+      return res.status(400).json({ message: "The club founder cannot be removed" });
+    }
+
+    club.members = club.members.filter((m) => m.user.toString() !== userId);
+    club.admins = club.admins.filter((a) => a.toString() !== userId);
+    club.markModified('members');
+    club.markModified('admins');
+    await club.save();
+
+    const populated = await populateClub(Club.findById(club._id));
+    res.json(populated);
+  } catch (err) {
+    console.error("Remove member error:", err);
+    res.status(500).json({ message: "Failed to remove member" });
+  }
+};
+
+// ─── Update a member's leadership role ──────────────────────────────────────────────────
+export const updateMemberRole = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const adminId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, adminId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can assign leadership roles" });
+    }
+
+    const { userId } = req.params;
+    const { role, makeAdmin } = req.body;
+
+    if (role && !ROLES.includes(role)) {
+      return res.status(400).json({ message: `Role must be one of: ${ROLES.join(", ")}` });
+    }
+
+    const member = club.members.find((m) => m.user.toString() === userId);
+    if (!member) return res.status(404).json({ message: "User is not a member of this club" });
+
+    if (role) member.role = role;
+
+    if (makeAdmin === true && !club.admins.some((a) => a.toString() === userId)) {
+      club.admins.push(userId);
+    } else if (makeAdmin === false) {
+      club.admins = club.admins.filter((a) => a.toString() !== userId);
+    }
+
+    club.markModified('members');
+    club.markModified('admins');
+    await club.save();
+    
+    const populated = await populateClub(Club.findById(club._id));
+    res.json(populated);
+  } catch (err) {
+    console.error("Update member role error:", err);
+    res.status(500).json({ message: "Failed to update member role" });
+  }
+};
+
+// ─── Link an existing event to a club ──────────────────────────────────────────────────
+export const linkEventToClub = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const adminId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, adminId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can link events" });
+    }
+
+    const { eventId } = req.body;
+    if (!eventId || !mongoose.Types.ObjectId.isValid(eventId)) {
+      return res.status(400).json({ message: "A valid eventId is required" });
+    }
+
+    const event = await Event.findById(eventId);
+    if (!event) return res.status(404).json({ message: "Event not found" });
+
+    if (!club.events.some((e) => e.toString() === eventId)) {
+      club.events.push(eventId);
+      club.markModified('events');
+      await club.save();
+    }
+
+    event.organization = club.name;
+    await event.save();
+
+    const populated = await populateClub(Club.findById(club._id));
+    res.json(populated);
+  } catch (err) {
+    console.error("Link event error:", err);
+    res.status(500).json({ message: "Failed to link event to club" });
+  }
+};
+
+// ─── Unlink an event from a club ────────────────────────────────────────────────────────
+export const unlinkEventFromClub = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const adminId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, adminId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can unlink events" });
+    }
+
+    const { eventId } = req.params;
+    club.events = club.events.filter((e) => e.toString() !== eventId);
+    club.markModified('events');
+    await club.save();
+
+    const populated = await populateClub(Club.findById(club._id));
+    res.json(populated);
+  } catch (err) {
+    console.error("Unlink event error:", err);
+    res.status(500).json({ message: "Failed to unlink event from club" });
+  }
+};
+
+// ─── Get events for a club ───────────────────────────────────────────────────────────────
+export const getClubEvents = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id).populate({
+      path: "events",
+      options: { sort: { date: 1 } },
+    });
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    res.json(club.events);
+  } catch (err) {
+    console.error("Get club events error:", err);
+    res.status(500).json({ message: "Failed to fetch club events" });
+  }
+};
+// ─── Post an Announcement ──────────────────────────────────────────────────────────
+export const addAnnouncement = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const userId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, userId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can post announcements" });
+    }
+
+    if (!req.body.message) {
+      return res.status(400).json({ message: "Message text is required" });
+    }
+
+    club.announcements.unshift({
+      message: req.body.message,
+      postedBy: userId
+    });
+    
+    club.markModified('announcements');
+    await club.save();
+
+    const populated = await populateClub(Club.findById(club._id));
+    res.status(201).json(populated);
+  } catch (err) {
+    console.error("Add announcement error:", err);
+    res.status(500).json({ message: "Failed to post announcement" });
+  }
+};
+
+// ─── Delete an Announcement ────────────────────────────────────────────────────────
+export const deleteAnnouncement = async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    const userId = req.user._id || req.user.id;
+
+    if (!club) return res.status(404).json({ message: "Club not found" });
+
+    if (!isAdminOf(club, userId) && req.user.role !== "hod") {
+      return res.status(403).json({ message: "Only club admins can delete announcements" });
+    }
+
+    club.announcements = club.announcements.filter(
+      (a) => a._id.toString() !== req.params.announcementId
+    );
+    
+    club.markModified('announcements');
+    await club.save();
+
+    const populated = await populateClub(Club.findById(club._id));
+    res.json(populated);
+  } catch (err) {
+    console.error("Delete announcement error:", err);
+    res.status(500).json({ message: "Failed to delete announcement" });
+  }
+};

--- a/collegems-server/src/controllers/user.controller.js
+++ b/collegems-server/src/controllers/user.controller.js
@@ -21,19 +21,7 @@ const normalizeSettings = (settings) => {
   };
 };
 
-const calculateProfileCompletion = (user) => {
-  const fields = ['name', 'email', 'phone', 'department', 'studentId', 'course', 'semester'];
-  let filled = 0;
-  const missingFields = [];
-  fields.forEach(field => {
-    if (user[field]) filled++;
-    else missingFields.push(field);
-  });
-  return {
-    percentage: Math.round((filled / fields.length) * 100),
-    missingFields
-  };
-};
+
 
 export const getMe = async (req, res) => {
   try {

--- a/collegems-server/src/models/Club.model.js
+++ b/collegems-server/src/models/Club.model.js
@@ -1,0 +1,118 @@
+import mongoose from "mongoose";
+
+const LEADERSHIP_ROLES = [
+  "member",
+  "coordinator",
+  "secretary",
+  "treasurer",
+  "vice-president",
+  "president",
+];
+
+const memberSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    role: {
+      type: String,
+      enum: LEADERSHIP_ROLES,
+      default: "member",
+    },
+    joinedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { _id: false }
+);
+
+const joinRequestSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    message: {
+      type: String,
+      trim: true,
+    },
+    requestedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { _id: false }
+);
+
+const clubSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      unique: true,
+    },
+    description: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    category: {
+      type: String,
+      enum: [
+        "Technical", "Cultural", "Sports", "Literary",
+        "Social Service", "Arts", "Music", "Dance",
+        "Photography", "Entrepreneurship", "Other",
+      ],
+      default: "Other",
+    },
+    logo: {
+      type: String,
+    },
+    createdBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    admins: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+      },
+    ],
+    members: [memberSchema],
+    pendingRequests: [joinRequestSchema],
+   events: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Event",
+      },
+    ],
+    
+    announcements: [
+      {
+        message: { type: String, required: true },
+        postedBy: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+        date: { type: Date, default: Date.now }
+      }
+    ],
+    maxMembers: {
+      type: Number,
+      default: 100,
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  { timestamps: true }
+);
+
+clubSchema.index({ "members.user": 1 });
+
+export const ROLES = LEADERSHIP_ROLES;
+export default mongoose.model("Club", clubSchema);

--- a/collegems-server/src/models/Events.model.js
+++ b/collegems-server/src/models/Events.model.js
@@ -19,6 +19,10 @@ const EventsSchema = new mongoose.Schema(
             required: true,
             trim: true,
         },
+        club: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Club",
+         },
 
         description: {
             type: String,

--- a/collegems-server/src/routes/clubs.routes.js
+++ b/collegems-server/src/routes/clubs.routes.js
@@ -1,0 +1,52 @@
+import express from "express";
+import { protect } from "../middlewares/auth.middleware.js";
+import { allowRoles } from "../middlewares/role.middleware.js";
+import {
+  createClub,
+  getAllClubs,
+  getClubById,
+  getMyClubs,
+  updateClub,
+  deleteClub,
+  requestToJoin,
+  getPendingRequests,
+  approveRequest,
+  rejectRequest,
+  removeMember,
+  updateMemberRole,
+  linkEventToClub,
+  unlinkEventFromClub,
+  getClubEvents,
+  addAnnouncement, 
+  deleteAnnouncement,
+} from "../controllers/clubs.controller.js";
+
+const router = express.Router();
+
+// ── General (any authenticated user: student, teacher, hod) ──────────────────
+router.post("/", protect, allowRoles("student", "teacher", "hod"), createClub);
+router.get("/", protect, allowRoles("student", "teacher", "hod"), getAllClubs);
+router.get("/my", protect, allowRoles("student", "teacher", "hod"), getMyClubs);
+router.get("/:id", protect, allowRoles("student", "teacher", "hod"), getClubById);
+
+router.put("/:id", protect, allowRoles("student", "teacher", "hod"), updateClub);
+router.delete("/:id", protect, allowRoles("student", "teacher", "hod"), deleteClub);
+
+// ── Membership ─────────────────────────────────────────────────────────────────
+router.post("/:id/join", protect, allowRoles("student", "teacher", "hod"), requestToJoin);
+router.get("/:id/requests", protect, allowRoles("student", "teacher", "hod"), getPendingRequests);
+router.post("/:id/requests/:userId/approve", protect, allowRoles("student", "teacher", "hod"), approveRequest);
+router.post("/:id/requests/:userId/reject", protect, allowRoles("student", "teacher", "hod"), rejectRequest);
+router.delete("/:id/members/:userId", protect, allowRoles("student", "teacher", "hod"), removeMember);
+router.put("/:id/members/:userId/role", protect, allowRoles("student", "teacher", "hod"), updateMemberRole);
+
+// ── Events ──────────────────────────────────────────────────────────────────────
+router.get("/:id/events", protect, allowRoles("student", "teacher", "hod"), getClubEvents);
+router.post("/:id/events", protect, allowRoles("student", "teacher", "hod"), linkEventToClub);
+router.delete("/:id/events/:eventId", protect, allowRoles("student", "teacher", "hod"), unlinkEventFromClub);
+
+// ── Announcements ──────────────────────────────────────────────────────────────────
+router.post("/:id/announcements", protect, allowRoles("student", "teacher", "hod"), addAnnouncement);
+router.delete("/:id/announcements/:announcementId", protect, allowRoles("student", "teacher", "hod"), deleteAnnouncement);
+
+export default router;


### PR DESCRIPTION

What changed and why
I’ve added a new feature that lets club presidents link college-wide events directly to their club pages. Before this, clubs were isolated from the main college event schedule. Now, when an event is added to the college calendar, a club admin can simply select it from a dropdown in their Management tab to feature it on their club page.

I also spent some time cleaning up some stubborn bugs that were making the dashboard behave erratically. The permission system was getting a bit messy—users were seeing "Request Pending" on their own clubs and "Manage" buttons were appearing for the wrong people. I’ve rewritten the identification logic to be much more reliable, so now the right people see the right buttons, every time.

Roles affected
Student (Club Presidents/Admins): This is the primary group affected. They now have access to the new Event Linking feature and proper Admin permissions in the dashboard.

Student (General Members): No changes to their view, but they will now see events linked to their club.

UI Changes
Event Linking Dropdown: Added a new "Events" tab in the ClubManagement dashboard with a searchable dropdown to link college events.

Button Permissions: Cleaned up the dashboard so only the President/Founder sees the "Delete Club" and "Kick Member" buttons.

API Changes
POST /api/clubs/:id/events: New endpoint to link an existing event ID to a specific club.

DELETE /api/clubs/:id/events/:eventId: New endpoint to remove a link if an event is cancelled or incorrectly added.

Issue Resolved
Closes #12