### PR TITLE
feat: Auto Close Old Academic Sessions (#277)

### DIFF
--- a/collegems-client/src/hod-components/SemesterManagement.tsx
+++ b/collegems-client/src/hod-components/SemesterManagement.tsx
@@ -1,144 +1,560 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import api from "../api/axios";
-import { Lock, Unlock, Plus } from "lucide-react";
+import {
+  Lock,
+  Unlock,
+  Plus,
+  Play,
+  RotateCcw,
+  Calendar,
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  ChevronRight,
+  X,
+  Loader2,
+  ShieldCheck,
+  BookOpen,
+} from "lucide-react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 interface Semester {
+  _id: string;
   semester: string;
   isFrozen: boolean;
-  frozenAt?: string;
+  isActive: boolean;
+  activatedAt?: string;
+  deactivatedAt?: string;
+  activatedBy?: { name: string };
+  frozenBy?: { name: string };
+  createdAt: string;
 }
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const formatDate = (iso?: string) => {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+};
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+/** Confirmation modal shown before activating a new session */
+const ConfirmActivateModal: React.FC<{
+  newSession: string;
+  activeCount: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading: boolean;
+}> = ({ newSession, activeCount, onConfirm, onCancel, loading }) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    {/* Backdrop */}
+    <div
+      className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+      onClick={onCancel}
+    />
+    {/* Modal */}
+    <div className="relative bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-md w-full p-6 border border-gray-200 dark:border-gray-700 animate-in fade-in zoom-in-95 duration-200">
+      {/* Close */}
+      <button
+        onClick={onCancel}
+        className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+      >
+        <X size={20} />
+      </button>
+
+      {/* Icon */}
+      <div className="flex items-center justify-center w-14 h-14 rounded-full bg-amber-100 dark:bg-amber-900/30 mx-auto mb-4">
+        <AlertTriangle size={28} className="text-amber-500" />
+      </div>
+
+      <h3 className="text-lg font-bold text-center text-gray-900 dark:text-white mb-2">
+        Activate New Academic Session?
+      </h3>
+
+      <p className="text-sm text-gray-600 dark:text-gray-400 text-center mb-4">
+        You are about to activate{" "}
+        <span className="font-semibold text-gray-900 dark:text-white">
+          "{newSession}"
+        </span>{" "}
+        as the current academic session.
+      </p>
+
+      {activeCount > 0 && (
+        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-4 mb-4">
+          <div className="flex gap-2 items-start">
+            <AlertTriangle size={16} className="text-amber-500 mt-0.5 shrink-0" />
+            <p className="text-xs text-amber-700 dark:text-amber-300 leading-relaxed">
+              <span className="font-semibold">{activeCount} currently-active session(s)</span> will
+              be automatically <span className="font-semibold">frozen (read-only)</span>. No new
+              records (attendance, results, assignments) can be created inside
+              them until manually reopened.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <p className="text-xs text-gray-500 dark:text-gray-500 text-center mb-6">
+        Historical data in all sessions remains fully accessible and readable.
+      </p>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onCancel}
+          className="flex-1 px-4 py-2.5 rounded-xl border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          disabled={loading}
+          className="flex-1 px-4 py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold transition-colors disabled:opacity-60 flex items-center justify-center gap-2"
+        >
+          {loading ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            <Play size={16} />
+          )}
+          {loading ? "Activating…" : "Yes, Activate"}
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+// ─── Status Badge ─────────────────────────────────────────────────────────────
+
+const StatusBadge: React.FC<{ sem: Semester }> = ({ sem }) => {
+  if (sem.isActive) {
+    return (
+      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800">
+        <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+        Active
+      </span>
+    );
+  }
+  if (sem.isFrozen) {
+    return (
+      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border border-blue-200 dark:border-blue-800">
+        <Lock size={10} />
+        Frozen
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600">
+      <Unlock size={10} />
+      Open
+    </span>
+  );
+};
+
+// ─── Main Component ───────────────────────────────────────────────────────────
 
 const SemesterManagement: React.FC = () => {
   const [semesters, setSemesters] = useState<Semester[]>([]);
   const [loading, setLoading] = useState(true);
-  const [customSemester, setCustomSemester] = useState("");
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
 
-  const defaultSemesters = ["1", "2", "3", "4", "5", "6", "7", "8"];
+  // New session form
+  const [newSessionName, setNewSessionName] = useState("");
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [activating, setActivating] = useState(false);
 
-  const fetchSemesters = async () => {
+  // Toast / feedback
+  const [toast, setToast] = useState<{ msg: string; type: "success" | "error" } | null>(null);
+
+  // ── Fetch ──────────────────────────────────────────────────────────────────
+  const fetchSemesters = useCallback(async () => {
     try {
       setLoading(true);
       const { data } = await api.get("/semesters");
       setSemesters(data);
     } catch (error) {
       console.error("Error fetching semesters", error);
+      showToast("Failed to load sessions.", "error");
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchSemesters();
-  }, []);
+  }, [fetchSemesters]);
 
-  const toggleFreeze = async (semesterStr: string, currentStatus: boolean) => {
+  // ── Toast helper ───────────────────────────────────────────────────────────
+  const showToast = (msg: string, type: "success" | "error") => {
+    setToast({ msg, type });
+    setTimeout(() => setToast(null), 4000);
+  };
+
+  // ── Activate new session ───────────────────────────────────────────────────
+  const handleActivate = async () => {
     try {
-      const isFrozen = !currentStatus;
-      await api.post(`/semesters/${semesterStr}/toggle`, { isFrozen });
-      fetchSemesters();
-    } catch (error: any) {
-      console.error("Error toggling freeze status", error);
-      alert(error.response?.data?.message || "Failed to toggle freeze status.");
+      setActivating(true);
+      const { data } = await api.post("/semesters/activate", {
+        semester: newSessionName.trim(),
+      });
+      showToast(data.message, "success");
+      setNewSessionName("");
+      setShowConfirm(false);
+      await fetchSemesters();
+    } catch (err: any) {
+      showToast(err.response?.data?.message || "Failed to activate session.", "error");
+    } finally {
+      setActivating(false);
     }
   };
 
-  const handleCustomAdd = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!customSemester.trim()) return;
-    
-    // We just display it by trying to freeze it. If they add it, let's freeze it by default to register it.
-    toggleFreeze(customSemester.trim(), false);
-    setCustomSemester("");
+  // ── Toggle freeze ──────────────────────────────────────────────────────────
+  const handleToggleFreeze = async (sem: Semester) => {
+    const key = `toggle-${sem._id}`;
+    try {
+      setActionLoading(key);
+      const newFrozen = !sem.isFrozen;
+      const { data } = await api.post(`/semesters/${sem.semester}/toggle`, {
+        isFrozen: newFrozen,
+      });
+      showToast(data.message, "success");
+      await fetchSemesters();
+    } catch (err: any) {
+      showToast(err.response?.data?.message || "Failed to update freeze status.", "error");
+    } finally {
+      setActionLoading(null);
+    }
   };
 
-  // Merge default semesters with fetched ones
-  const displayList = [...defaultSemesters];
-  semesters.forEach((sem) => {
-    if (!displayList.includes(sem.semester)) {
-      displayList.push(sem.semester);
+  // ── Reopen session ─────────────────────────────────────────────────────────
+  const handleReopen = async (sem: Semester) => {
+    const key = `reopen-${sem._id}`;
+    try {
+      setActionLoading(key);
+      const { data } = await api.post(`/semesters/${sem.semester}/reopen`);
+      showToast(data.message, "success");
+      await fetchSemesters();
+    } catch (err: any) {
+      showToast(err.response?.data?.message || "Failed to reopen session.", "error");
+    } finally {
+      setActionLoading(null);
     }
-  });
-  
-  // Sort numeric strings correctly
-  displayList.sort((a, b) => {
-    const numA = parseInt(a);
-    const numB = parseInt(b);
-    if (!isNaN(numA) && !isNaN(numB)) return numA - numB;
-    return a.localeCompare(b);
-  });
+  };
 
+  // ── Derived ────────────────────────────────────────────────────────────────
+  const activeSession = semesters.find((s) => s.isActive);
+  const activeSessions = semesters.filter((s) => s.isActive);
+  const otherSessions = semesters.filter((s) => !s.isActive);
+
+  // ── Loading state ──────────────────────────────────────────────────────────
   if (loading) {
-    return <div className="p-6 text-center text-gray-500">Loading semester data...</div>;
-  }
-
-  return (
-    <div className="p-6">
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 mb-6">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Freeze Semesters</h2>
-        <p className="text-gray-500 dark:text-gray-400 mb-6 text-sm">
-          Marking a semester as completed (frozen) prevents any accidental modifications to its academic data (Results, Attendance, Assignments, Timetable).
-        </p>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          {displayList.map((semStr) => {
-            const dbSem = semesters.find((s) => s.semester === semStr);
-            const isFrozen = dbSem ? dbSem.isFrozen : false;
-
-            return (
-              <div
-                key={semStr}
-                className={`p-4 border rounded-xl flex items-center justify-between transition-colors ${
-                  isFrozen
-                    ? "bg-blue-50 border-blue-200 dark:bg-blue-900/20 dark:border-blue-800"
-                    : "bg-gray-50 border-gray-200 dark:bg-gray-800 dark:border-gray-700"
-                }`}
-              >
-                <div>
-                  <h3 className={`font-semibold ${isFrozen ? "text-blue-700 dark:text-blue-400" : "text-gray-700 dark:text-gray-300"}`}>
-                    Semester {semStr}
-                  </h3>
-                  <span className={`text-xs px-2 py-1 rounded-full mt-2 inline-block ${
-                    isFrozen ? "bg-blue-100 text-blue-800" : "bg-gray-200 text-gray-700"
-                  }`}>
-                    {isFrozen ? "Completed (Frozen)" : "Active"}
-                  </span>
-                </div>
-                <button
-                  onClick={() => toggleFreeze(semStr, isFrozen)}
-                  className={`p-2 rounded-full transition-colors ${
-                    isFrozen
-                      ? "bg-blue-600 hover:bg-blue-700 text-white"
-                      : "bg-white border border-gray-300 text-gray-600 hover:bg-gray-100 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300"
-                  }`}
-                  title={isFrozen ? "Unfreeze Semester" : "Freeze Semester"}
-                >
-                  {isFrozen ? <Lock size={18} /> : <Unlock size={18} />}
-                </button>
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
-          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Add Custom Semester (e.g. "Fall 2024")</h3>
-          <form onSubmit={handleCustomAdd} className="flex gap-2 max-w-sm">
-            <input
-              type="text"
-              value={customSemester}
-              onChange={(e) => setCustomSemester(e.target.value)}
-              placeholder="Semester identifier"
-              className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
-            />
-            <button
-              type="submit"
-              disabled={!customSemester.trim()}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center gap-2 disabled:opacity-50"
-            >
-              <Plus size={16} /> Add
-            </button>
-          </form>
+    return (
+      <div className="p-6 flex items-center justify-center min-h-64">
+        <div className="flex flex-col items-center gap-3">
+          <Loader2 size={32} className="animate-spin text-blue-500" />
+          <p className="text-sm text-gray-500 dark:text-gray-400">Loading academic sessions…</p>
         </div>
       </div>
+    );
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <div className="p-4 md:p-6 space-y-6 max-w-5xl">
+      {/* ── Toast ── */}
+      {toast && (
+        <div
+          className={`fixed top-4 right-4 z-50 flex items-center gap-3 px-5 py-3 rounded-xl shadow-lg text-sm font-medium text-white transition-all duration-300 ${
+            toast.type === "success" ? "bg-emerald-600" : "bg-red-600"
+          }`}
+        >
+          {toast.type === "success" ? (
+            <CheckCircle2 size={16} />
+          ) : (
+            <AlertTriangle size={16} />
+          )}
+          {toast.msg}
+        </div>
+      )}
+
+      {/* ── No Active Session Banner ── */}
+      {!activeSession && (
+        <div className="flex items-start gap-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl px-5 py-4">
+          <AlertTriangle size={20} className="text-amber-500 mt-0.5 shrink-0" />
+          <div>
+            <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+              No active academic session
+            </p>
+            <p className="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
+              New records (attendance, results, assignments) cannot be restricted to a session until one is activated.
+              Use the panel below to start a new session.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Active Session Hero Card ── */}
+      {activeSession && (
+        <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-emerald-500 via-emerald-600 to-teal-700 p-6 text-white shadow-lg">
+          {/* Background decoration */}
+          <div className="absolute -top-8 -right-8 w-40 h-40 rounded-full bg-white/10" />
+          <div className="absolute -bottom-6 -left-6 w-28 h-28 rounded-full bg-white/10" />
+
+          <div className="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div className="flex items-center gap-4">
+              <div className="w-14 h-14 rounded-2xl bg-white/20 flex items-center justify-center shrink-0">
+                <ShieldCheck size={28} className="text-white" />
+              </div>
+              <div>
+                <p className="text-emerald-100 text-xs font-medium uppercase tracking-widest mb-1">
+                  Current Active Session
+                </p>
+                <h2 className="text-2xl font-bold">{activeSession.semester}</h2>
+                <div className="flex items-center gap-2 mt-1">
+                  <span className="w-2 h-2 rounded-full bg-green-300 animate-pulse" />
+                  <span className="text-emerald-100 text-xs">
+                    Activated {formatDate(activeSession.activatedAt)}
+                    {activeSession.activatedBy?.name && ` by ${activeSession.activatedBy.name}`}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3 shrink-0">
+              <div className="text-right">
+                <p className="text-emerald-100 text-xs">Status</p>
+                <p className="text-sm font-semibold flex items-center gap-1 justify-end">
+                  <CheckCircle2 size={14} />
+                  Open for entries
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Start New Session Panel ── */}
+      <div className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-6">
+        <div className="flex items-center gap-3 mb-1">
+          <div className="w-9 h-9 rounded-xl bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+            <Plus size={18} className="text-blue-600 dark:text-blue-400" />
+          </div>
+          <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+            Start New Academic Session
+          </h3>
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-5 ml-12">
+          Activating a new session will automatically freeze all currently-open sessions (making them read-only).
+          Historical data in those sessions will still be fully accessible.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 ml-0 sm:ml-12">
+          <input
+            id="new-session-name"
+            type="text"
+            value={newSessionName}
+            onChange={(e) => setNewSessionName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && newSessionName.trim()) setShowConfirm(true);
+            }}
+            placeholder='e.g. "Fall 2025-26" or "Semester 3"'
+            className="flex-1 px-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-900 text-gray-900 dark:text-white text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+          />
+          <button
+            type="button"
+            disabled={!newSessionName.trim()}
+            onClick={() => setShowConfirm(true)}
+            className="flex items-center gap-2 px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-xl transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
+          >
+            <Play size={15} />
+            Activate Session
+          </button>
+        </div>
+      </div>
+
+      {/* ── Sessions Table ── */}
+      <div className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-xl bg-purple-100 dark:bg-purple-900/30 flex items-center justify-center">
+              <BookOpen size={18} className="text-purple-600 dark:text-purple-400" />
+            </div>
+            <div>
+              <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                All Academic Sessions
+              </h3>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {semesters.length} session{semesters.length !== 1 ? "s" : ""} total
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {semesters.length === 0 ? (
+          <div className="py-16 text-center text-gray-500 dark:text-gray-400">
+            <Calendar size={40} className="mx-auto mb-3 opacity-30" />
+            <p className="text-sm font-medium">No sessions yet</p>
+            <p className="text-xs mt-1">Create your first academic session above.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-900/50 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <th className="text-left px-6 py-3">Session</th>
+                  <th className="text-left px-4 py-3">Status</th>
+                  <th className="text-left px-4 py-3 hidden md:table-cell">Activated On</th>
+                  <th className="text-left px-4 py-3 hidden lg:table-cell">Closed On</th>
+                  <th className="text-left px-4 py-3 hidden lg:table-cell">Closed By</th>
+                  <th className="text-right px-6 py-3">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {semesters.map((sem) => {
+                  const isToggling = actionLoading === `toggle-${sem._id}`;
+                  const isReopening = actionLoading === `reopen-${sem._id}`;
+                  const anyLoading = isToggling || isReopening;
+
+                  return (
+                    <tr
+                      key={sem._id}
+                      className={`transition-colors ${
+                        sem.isActive
+                          ? "bg-emerald-50/50 dark:bg-emerald-900/10"
+                          : "hover:bg-gray-50 dark:hover:bg-gray-900/30"
+                      }`}
+                    >
+                      {/* Session name */}
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-2">
+                          {sem.isActive && (
+                            <ChevronRight
+                              size={14}
+                              className="text-emerald-500 shrink-0"
+                            />
+                          )}
+                          <span
+                            className={`font-semibold ${
+                              sem.isActive
+                                ? "text-emerald-700 dark:text-emerald-400"
+                                : "text-gray-800 dark:text-gray-200"
+                            }`}
+                          >
+                            {sem.semester}
+                          </span>
+                        </div>
+                      </td>
+
+                      {/* Status */}
+                      <td className="px-4 py-4">
+                        <StatusBadge sem={sem} />
+                      </td>
+
+                      {/* Activated On */}
+                      <td className="px-4 py-4 hidden md:table-cell text-gray-500 dark:text-gray-400 text-xs">
+                        <div className="flex items-center gap-1.5">
+                          <Clock size={12} className="shrink-0" />
+                          {formatDate(sem.activatedAt)}
+                        </div>
+                      </td>
+
+                      {/* Closed On */}
+                      <td className="px-4 py-4 hidden lg:table-cell text-gray-500 dark:text-gray-400 text-xs">
+                        {sem.deactivatedAt ? (
+                          <div className="flex items-center gap-1.5">
+                            <Lock size={12} className="shrink-0" />
+                            {formatDate(sem.deactivatedAt)}
+                          </div>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+
+                      {/* Closed By */}
+                      <td className="px-4 py-4 hidden lg:table-cell text-gray-500 dark:text-gray-400 text-xs">
+                        {sem.frozenBy?.name ?? "—"}
+                      </td>
+
+                      {/* Actions */}
+                      <td className="px-6 py-4">
+                        <div className="flex items-center justify-end gap-2">
+                          {/* Reopen button — only shown for frozen sessions */}
+                          {sem.isFrozen && !sem.isActive && (
+                            <button
+                              onClick={() => handleReopen(sem)}
+                              disabled={anyLoading}
+                              title="Reopen this session (remove read-only)"
+                              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50 transition-colors disabled:opacity-50"
+                            >
+                              {isReopening ? (
+                                <Loader2 size={12} className="animate-spin" />
+                              ) : (
+                                <RotateCcw size={12} />
+                              )}
+                              Reopen
+                            </button>
+                          )}
+
+                          {/* Freeze / Unfreeze toggle */}
+                          <button
+                            onClick={() => handleToggleFreeze(sem)}
+                            disabled={anyLoading}
+                            title={sem.isFrozen ? "Unfreeze semester" : "Freeze semester"}
+                            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors disabled:opacity-50 ${
+                              sem.isFrozen
+                                ? "bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+                                : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                            }`}
+                          >
+                            {isToggling ? (
+                              <Loader2 size={12} className="animate-spin" />
+                            ) : sem.isFrozen ? (
+                              <Unlock size={12} />
+                            ) : (
+                              <Lock size={12} />
+                            )}
+                            {sem.isFrozen ? "Unfreeze" : "Freeze"}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Legend */}
+        <div className="px-6 py-4 border-t border-gray-100 dark:border-gray-700 flex flex-wrap gap-4 text-xs text-gray-500 dark:text-gray-400">
+          <div className="flex items-center gap-1.5">
+            <span className="w-2 h-2 rounded-full bg-emerald-500" />
+            <span>Active — open for new entries</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Lock size={11} />
+            <span>Frozen — read-only, historical data accessible</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Unlock size={11} />
+            <span>Open — not active but editable</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Confirm Modal ── */}
+      {showConfirm && (
+        <ConfirmActivateModal
+          newSession={newSessionName.trim()}
+          activeCount={activeSessions.length}
+          onConfirm={handleActivate}
+          onCancel={() => setShowConfirm(false)}
+          loading={activating}
+        />
+      )}
     </div>
   );
 };

--- a/collegems-server/src/app.js
+++ b/collegems-server/src/app.js
@@ -63,6 +63,7 @@ import timetableRoutes from './routes/timetable.routes.js'
 import plagiarismRoutes from "./routes/plagiarism.routes.js";
 import workflowRoutes from "./routes/workflow.routes.js";
 import dependencyRoutes from "./routes/dependency.routes.js";
+import semesterRoutes from "./routes/semester.routes.js";
 import log from "./utils/logger.js";
 
 import httpContext from "express-http-context";
@@ -159,6 +160,7 @@ app.use("/api/analytics", authenticate, analyticsRoutes);
 app.use("/api/timetable", authenticate, timetableRoutes);
 app.use("/api/workflows", workflowRoutes);
 app.use("/api/dependencies", dependencyRoutes);
+app.use("/api/semesters", semesterRoutes);
 
 // Health check
 app.get("/", (_req, res) => {

--- a/collegems-server/src/controllers/semester.controller.js
+++ b/collegems-server/src/controllers/semester.controller.js
@@ -1,10 +1,19 @@
 import Semester from "../models/Semester.model.js";
 import { logAction } from "../utils/auditService.js";
 
-// Get all semesters and their statuses
+// ─── GET ALL SEMESTERS ────────────────────────────────────────────────────────
+/**
+ * @route   GET /api/semesters
+ * @access  Authenticated
+ * Returns all semester/session records sorted with the active session first,
+ * then the rest by semester name.
+ */
 export const getSemesters = async (req, res) => {
   try {
-    const semesters = await Semester.find().sort({ semester: 1 });
+    const semesters = await Semester.find()
+      .sort({ isActive: -1, createdAt: -1 })
+      .populate("frozenBy", "name")
+      .populate("activatedBy", "name");
     res.json(semesters);
   } catch (error) {
     console.error("Get Semesters Error:", error);
@@ -12,7 +21,84 @@ export const getSemesters = async (req, res) => {
   }
 };
 
-// Toggle semester freeze status
+// ─── CREATE OR ACTIVATE SESSION ───────────────────────────────────────────────
+/**
+ * @route   POST /api/semesters/activate
+ * @access  HOD / Admin
+ * Creates (or finds) the target semester and marks it as the one active session.
+ * All previously-active sessions are automatically frozen (read-only).
+ */
+export const createOrActivateSession = async (req, res) => {
+  try {
+    const { semester } = req.body;
+
+    if (!semester || !String(semester).trim()) {
+      return res.status(400).json({ message: "Semester / session name is required" });
+    }
+
+    const semesterStr = String(semester).trim();
+    const now = new Date();
+    const adminId = req.user.id;
+
+    // ── Step 1: Auto-close all currently-active sessions ──────────────────────
+    const previouslyActive = await Semester.find({ isActive: true });
+
+    for (const prev of previouslyActive) {
+      prev.isActive = false;
+      prev.isFrozen = true;
+      prev.frozenBy = adminId;
+      prev.deactivatedAt = now;
+      await prev.save();
+
+      await logAction(
+        adminId,
+        "DEACTIVATE_SEMESTER",
+        "Semester",
+        prev._id,
+        { semester: prev.semester, reason: `Auto-closed when activating new session: ${semesterStr}` }
+      );
+    }
+
+    // ── Step 2: Find or create the target session ─────────────────────────────
+    let target = await Semester.findOne({ semester: semesterStr });
+
+    if (!target) {
+      target = new Semester({ semester: semesterStr });
+    }
+
+    target.isActive = true;
+    target.isFrozen = false;
+    target.frozenBy = null;
+    target.activatedAt = now;
+    target.deactivatedAt = null;
+    target.activatedBy = adminId;
+    await target.save();
+
+    await logAction(
+      adminId,
+      "ACTIVATE_SEMESTER",
+      "Semester",
+      target._id,
+      { semester: semesterStr, previouslyClosed: previouslyActive.map((p) => p.semester) }
+    );
+
+    res.status(200).json({
+      message: `Session "${semesterStr}" is now the active academic session. ${previouslyActive.length} previous session(s) have been frozen.`,
+      data: target,
+      closedSessions: previouslyActive.map((p) => p.semester),
+    });
+  } catch (error) {
+    console.error("Activate Session Error:", error);
+    res.status(500).json({ message: "Failed to activate academic session" });
+  }
+};
+
+// ─── TOGGLE SEMESTER FREEZE ───────────────────────────────────────────────────
+/**
+ * @route   POST /api/semesters/:semesterStr/toggle
+ * @access  HOD / Admin
+ * Manually freeze or unfreeze a semester. Does not change the isActive flag.
+ */
 export const toggleSemesterFreeze = async (req, res) => {
   try {
     const { semesterStr } = req.params;
@@ -46,5 +132,46 @@ export const toggleSemesterFreeze = async (req, res) => {
   } catch (error) {
     console.error("Toggle Semester Freeze Error:", error);
     res.status(500).json({ message: "Failed to update semester freeze status" });
+  }
+};
+
+// ─── REOPEN SESSION ───────────────────────────────────────────────────────────
+/**
+ * @route   POST /api/semesters/:semesterStr/reopen
+ * @access  HOD / Admin
+ * Manually reopens (unfreezes) a previously-frozen session.
+ * Does NOT automatically deactivate the currently-active session —
+ * admin is responsible for managing multiple open sessions if needed.
+ */
+export const reopenSession = async (req, res) => {
+  try {
+    const { semesterStr } = req.params;
+
+    const semester = await Semester.findOne({ semester: semesterStr });
+
+    if (!semester) {
+      return res.status(404).json({ message: `Session "${semesterStr}" not found` });
+    }
+
+    semester.isFrozen = false;
+    semester.frozenBy = null;
+    semester.deactivatedAt = null;
+    await semester.save();
+
+    await logAction(
+      req.user.id,
+      "REOPEN_SEMESTER",
+      "Semester",
+      semester._id,
+      { semester: semesterStr }
+    );
+
+    res.json({
+      message: `Session "${semesterStr}" has been reopened and is no longer read-only.`,
+      data: semester,
+    });
+  } catch (error) {
+    console.error("Reopen Session Error:", error);
+    res.status(500).json({ message: "Failed to reopen session" });
   }
 };

--- a/collegems-server/src/models/Semester.model.js
+++ b/collegems-server/src/models/Semester.model.js
@@ -16,8 +16,36 @@ const SemesterSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
     },
+    /**
+     * isActive – true for the single currently-open academic session.
+     * Only one semester should have isActive=true at a time.
+     * When a new session is activated, all others are automatically set
+     * to isActive=false and isFrozen=true (read-only).
+     */
+    isActive: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    /** Timestamp when this session was set as the active session. */
+    activatedAt: {
+      type: Date,
+      default: null,
+    },
+    /** Timestamp when this session was automatically deactivated (closed). */
+    deactivatedAt: {
+      type: Date,
+      default: null,
+    },
+    /** The user who activated this session. */
+    activatedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
   },
   { timestamps: true }
 );
 
 export default mongoose.model("Semester", SemesterSchema);
+

--- a/collegems-server/src/routes/semester.routes.js
+++ b/collegems-server/src/routes/semester.routes.js
@@ -1,13 +1,42 @@
 import express from "express";
-import { getSemesters, toggleSemesterFreeze } from "../controllers/semester.controller.js";
+import {
+  getSemesters,
+  toggleSemesterFreeze,
+  createOrActivateSession,
+  reopenSession,
+} from "../controllers/semester.controller.js";
 import { authenticate, restrictTo } from "../middlewares/auth.middleware.js";
 
 const router = express.Router();
 
-// Get all semesters
+// Get all semesters / sessions
 router.get("/", authenticate, getSemesters);
 
-// Toggle freeze status (Only HOD/Admin)
-router.post("/:semesterStr/toggle", authenticate, restrictTo("hod"), toggleSemesterFreeze);
+// Activate a new session (auto-closes all currently-active sessions)
+// Accessible by HOD and Admin
+router.post(
+  "/activate",
+  authenticate,
+  restrictTo("hod", "admin"),
+  createOrActivateSession
+);
+
+// Reopen (unfreeze) a previously-frozen session
+// Accessible by HOD and Admin
+router.post(
+  "/:semesterStr/reopen",
+  authenticate,
+  restrictTo("hod", "admin"),
+  reopenSession
+);
+
+// Manually toggle the freeze status of a semester
+// Accessible by HOD only (existing behaviour)
+router.post(
+  "/:semesterStr/toggle",
+  authenticate,
+  restrictTo("hod", "admin"),
+  toggleSemesterFreeze
+);
 
 export default router;

--- a/collegems-server/src/services/semesterService.js
+++ b/collegems-server/src/services/semesterService.js
@@ -17,3 +17,13 @@ export const checkSemesterFrozen = async (semesterStr) => {
     throw error;
   }
 };
+
+/**
+ * Returns the currently active academic session, or null if none exists.
+ * Useful for controllers that need to auto-fill the semester on new records.
+ * @returns {Promise<import('../models/Semester.model.js').default|null>}
+ */
+export const getActiveSession = async () => {
+  return Semester.findOne({ isActive: true }).lean();
+};
+


### PR DESCRIPTION
## Description

This PR introduces the ability to enforce a single active academic session at a time, automating the process of closing (freezing) old sessions to prevent accidental data entry in historical records.

Key changes include:
*   **Database Schema**: Added `isActive`, `activatedAt`, and `deactivatedAt` fields to the `Semester` model to track session lifecycle.
*   **Backend Logic**: 
    *   Created `createOrActivateSession` endpoint which automatically sets all existing active sessions to read-only (`isFrozen: true`, `isActive: false`) when a new session is started.
    *   Added a `reopenSession` endpoint allowing administrators to manually unfreeze a specific historical session if modifications are needed.
    *   **Bug Fix**: Properly registered the `/api/semesters` routes in `app.js` (they were previously unmounted and unreachable).
*   **Frontend Redesign**: completely overhauled the `SemesterManagement` UI in the HOD Dashboard to clearly distinguish the active session with a prominent hero card, introduced a modal confirmation when starting a new session (warning about auto-closing others), and provided action buttons to easily reopen frozen sessions.
*   **Audit Logging**: Integrated audit logs for all session transitions (`ACTIVATE_SEMESTER`, `DEACTIVATE_SEMESTER`, `REOPEN_SEMESTER`).

Closes #277

## Type of Change

- [x] Bug fix (Fixed missing route registration in app.js)
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation