### PR TITLE
Add semester comparison feature for student dashboard

### DIFF
--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -11,7 +11,6 @@ import TeacherDashboard from "./pages/TeacherDashboard";
 import HodDashboard from "./pages/HODDashboard";
 import ParentDashboard from "./pages/ParentDashboard";
 import MainDashboard from "./pages/MainDashboard";
-import ParentDashboard from "./pages/ParentDashboard";
 import DashboardLayout from "./layouts/DashboardLayout";
 
 import ExamSchedule from "./user-components/ExamSchedule";

--- a/collegems-client/src/pages/StudentDashboard.tsx
+++ b/collegems-client/src/pages/StudentDashboard.tsx
@@ -60,6 +60,7 @@ import StudentSeatView from "../user-components/StudentSeatView";
 import UpcomingExamsWidget from "../user-components/UpcomingExamWidget";
 import ResourceBooking from "../user-components/ResourceBooking";
 import AnnouncementsView from "../user-components/AnnouncementsView";
+import SemesterComparison from "../user-components/SemesterComparison";
 
 // HOD Components
 import Teachers from "../hod-components/Teachers";
@@ -88,7 +89,9 @@ type TabType =
   | "bus-routes"
   | "book-resources"
   | "subject-faculty"
+  | "semester-comparison"
   | "settings";
+
 
 // Consolidated and cleaned navigation items
 const navigationItems: {
@@ -108,6 +111,7 @@ const navigationItems: {
   { id: "faculty", label: "Faculty", icon: Users },
   { id: "subject-faculty", label: "Subject Faculty", icon: GraduationCap },
   { id: "results", label: "Results", icon: AwardIcon },
+  { id: "semester-comparison", label: "Semester Comparison", icon: TrendingUp },
   { id: "achievements", label: "Achievements", icon: Trophy },
   { id: "leave", label: "Leave Requests", icon: ClipboardList },
   { id: "library", label: "Library", icon: BookOpen },
@@ -616,6 +620,7 @@ export default function StudentDashboard() {
               {activeTab === "academic-calendar" && <AcademicCalendar role="student" />}
               {activeTab === "events" && <EventsStudent />}
               {activeTab === "results" && <StudentResults />}
+              {activeTab === "semester-comparison" && <SemesterComparison />}
               {activeTab === "achievements" && <StudentAchievements />}
               {activeTab === "announcements" && <AnnouncementsView />}
               {activeTab === "leave" && <LeaveRequest />}

--- a/collegems-client/src/user-components/SemesterComparison.tsx
+++ b/collegems-client/src/user-components/SemesterComparison.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from "react";
+import api from "../api/axios";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  CalendarCheck,
+  AwardIcon,
+  BookOpen,
+} from "lucide-react";
+
+export default function SemesterComparison() {
+  const [data, setData] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchComparison();
+  }, []);
+
+  const fetchComparison = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await api.get("/dashboard/semester-comparison");
+      setData(res.data);
+    } catch (err: any) {
+      setError(
+        err.response?.data?.message || "Failed to load semester comparison",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderTrend = (value: number) => {
+    if (value > 0)
+      return (
+        <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400 text-sm font-medium">
+          <TrendingUp className="w-4 h-4" /> +{value}
+        </span>
+      );
+    if (value < 0)
+      return (
+        <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400 text-sm font-medium">
+          <TrendingDown className="w-4 h-4" /> {value}
+        </span>
+      );
+    return (
+      <span className="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 text-sm font-medium">
+        <Minus className="w-4 h-4" /> 0
+      </span>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="text-center py-12">
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-2 border-blue-600 border-t-transparent"></div>
+        <p className="mt-2 text-gray-500 dark:text-gray-400">
+          Loading semester comparison...
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-600 dark:text-gray-400">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const chartData = [
+    {
+      metric: "Attendance %",
+      previous: data.previous.attendancePercentage,
+      current: data.current.attendancePercentage,
+    },
+    {
+      metric: "Avg. Marks",
+      previous: data.previous.averageMarks,
+      current: data.current.averageMarks,
+    },
+    {
+      metric: "Courses",
+      previous: data.previous.enrolledCourses,
+      current: data.current.enrolledCourses,
+    },
+  ];
+
+  const cards = [
+    {
+      title: "Attendance",
+      icon: CalendarCheck,
+      current: `${data.current.attendancePercentage}%`,
+      diff: data.difference.attendancePercentage,
+    },
+    {
+      title: "Average Marks",
+      icon: AwardIcon,
+      current: data.current.averageMarks,
+      diff: data.difference.averageMarks,
+    },
+    {
+      title: "Enrolled Courses",
+      icon: BookOpen,
+      current: data.current.enrolledCourses,
+      diff: data.difference.enrolledCourses,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Semester {data.previousSemester} vs Semester {data.currentSemester}
+        </h2>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          Comparing your current semester against the previous one.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {cards.map((card, index) => {
+          const Icon = card.icon;
+          return (
+            <div
+              key={index}
+              className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 p-5"
+            >
+              <div className="flex items-center gap-3 mb-3">
+                <div className="p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
+                  <Icon className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {card.title}
+                </p>
+              </div>
+              <div className="flex items-center justify-between">
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                  {card.current}
+                </p>
+                {renderTrend(card.diff)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Side-by-Side Comparison
+        </h3>
+        <div className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis dataKey="metric" stroke="#6b7280" />
+              <YAxis stroke="#6b7280" />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "white",
+                  borderColor: "#e5e7eb",
+                  color: "#111827",
+                  borderRadius: "8px",
+                  boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                }}
+              />
+              <Legend wrapperStyle={{ color: "#6b7280" }} />
+              <Bar
+                dataKey="previous"
+                name={`Semester ${data.previousSemester}`}
+                fill="#9ca3af"
+                radius={[4, 4, 0, 0]}
+              />
+              <Bar
+                dataKey="current"
+                name={`Semester ${data.currentSemester}`}
+                fill="#2563eb"
+                radius={[4, 4, 0, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/collegems-server/src/controllers/dashboard.controller.js
+++ b/collegems-server/src/controllers/dashboard.controller.js
@@ -4,6 +4,7 @@ import Assignment from "../models/Assignment.model.js";
 import Fee from "../models/Fee.model.js";
 import User from "../models/User.model.js";
 import Class from "../models/Classes.model.js";
+import Results from "../models/Results.model.js";
 
 export const getDashboardData = async (req, res) => {
   const { role, id } = req.user;
@@ -303,4 +304,80 @@ export const getDashboardData = async (req, res) => {
   }
 
   res.status(403).json({ message: "Invalid role" });
+};
+
+const getSemesterMetrics = async (studentId, semesterNumber) => {
+  const courses = await Course.find({ semester: semesterNumber }).select("_id").lean();
+  const courseIds = courses.map((c) => c._id);
+
+  const totalAttendance = await Attendance.countDocuments({
+    student: studentId,
+    course: { $in: courseIds },
+  });
+  const presentAttendance = await Attendance.countDocuments({
+    student: studentId,
+    course: { $in: courseIds },
+    status: "present",
+  });
+  const attendancePercentage = totalAttendance
+    ? Math.round((presentAttendance / totalAttendance) * 100)
+    : 0;
+
+  const results = await Results.find({
+    studentId,
+    semester: String(semesterNumber),
+  }).lean();
+  const averageMarks = results.length
+    ? Math.round(results.reduce((sum, r) => sum + (r.totalMarks || 0), 0) / results.length)
+    : 0;
+
+  const enrolledCourseIds = await Attendance.distinct("course", {
+    student: studentId,
+    course: { $in: courseIds },
+  });
+
+  return {
+    attendancePercentage,
+    averageMarks,
+    enrolledCourses: enrolledCourseIds.length,
+  };
+};
+
+export const getSemesterComparison = async (req, res) => {
+  try {
+    const { id } = req.user;
+    const user = await User.findById(id).select("semester").lean();
+
+    if (!user || !user.semester) {
+      return res.status(400).json({ message: "No semester information found for this account" });
+    }
+
+    const currentSemester = parseInt(user.semester, 10);
+    const previousSemester = currentSemester - 1;
+
+    if (previousSemester < 1) {
+      return res.status(400).json({
+        message: "No previous semester to compare against — you're in your first semester.",
+      });
+    }
+
+    const current = await getSemesterMetrics(id, currentSemester);
+    const previous = await getSemesterMetrics(id, previousSemester);
+
+    res.json({
+      success: true,
+      currentSemester,
+      previousSemester,
+      current,
+      previous,
+      difference: {
+        attendancePercentage: current.attendancePercentage - previous.attendancePercentage,
+        averageMarks: current.averageMarks - previous.averageMarks,
+        enrolledCourses: current.enrolledCourses - previous.enrolledCourses,
+      },
+    });
+  } catch (error) {
+    console.error("Semester comparison failed:", error);
+    res.status(500).json({ success: false, message: "Failed to compare semesters" });
+  }
 };

--- a/collegems-server/src/routes/dashboard.routes.js
+++ b/collegems-server/src/routes/dashboard.routes.js
@@ -1,9 +1,10 @@
 import express from "express";
-import { protect } from "../middlewares/auth.middleware.js";
-import { getDashboardData } from "../controllers/dashboard.controller.js";
+   import { protect } from "../middlewares/auth.middleware.js";
+   import { getDashboardData, getSemesterComparison } from "../controllers/dashboard.controller.js";
 
-const router = express.Router();
+   const router = express.Router();
 
-router.get("/", protect, getDashboardData);
+   router.get("/", protect, getDashboardData);
+   router.get("/semester-comparison", protect, getSemesterComparison);
 
-export default router;
+   export default router;


### PR DESCRIPTION
Closes #310

What this does
Adds a new "Semester Comparison" view to the student dashboard, comparing the student's current semester against the previous one across three metrics: attendance %, average marks, and enrolled courses.

Backend
- New `getSemesterComparison` endpoint at `GET /api/dashboard/semester-comparison`, added to the existing dashboard controller/routes.
- Computes attendance % and enrolled course count via `Attendance` (joined through `Course.semester`), and average marks via `Results.semester`.
- Returns current semester stats, previous semester stats, and the difference between them.

Frontend
- New `SemesterComparison.tsx` component (in `user-components`), following the existing dashboard card + recharts pattern used elsewhere (e.g. `Attendance.tsx`).
- Added a new sidebar nav item + tab in `StudentDashboard.tsx`.
- Also fixed an unrelated pre-existing bug in `App.tsx` — `ParentDashboard` was imported twice, which crashed the dev server on startup.

Testing
Tested locally with seeded demo data (Alice Johnson, Semester 3). Screenshots below.

Note: Semester 2 metrics show as 0 in the screenshots — this is expected, since the demo seed data only populates Semester 3 records. With real data for both semesters, the comparison would show real numbers on both sides.

Screenshots
<img width="1470" height="919" alt="Screenshot 2026-06-20 at 3 11 53 PM" src="https://github.com/user-attachments/assets/cf6879df-303f-4324-8920-18c639103c29" />
<img width="1470" height="919" alt="Screenshot 2026-06-20 at 3 48 34 PM" src="https://github.com/user-attachments/assets/5faa8669-63d3-4a30-aa49-aaccbeb895db" />
