### PR TITLE
feat: Add Back to Top Button for Long Scrollable Pages

### DIFF
--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -7,10 +7,10 @@ import ProtectedRoute from "./routes/ProtectedRoute";
 import BulkFieldReset from "./hod-components/BulkFieldReset";
 
 import TimeTable from "./user-components/TimeTable";
- import StudentDashboard from "./pages/StudentDashboard";
-import TimeTable from "./user-components/TimeTable";
-
 import StudentDashboard from "./pages/StudentDashboard";
+//import TimeTable from "./user-components/TimeTable";
+
+//import StudentDashboard from "./pages/StudentDashboard";
 import TeacherDashboard from "./pages/TeacherDashboard";
 import HodDashboard from "./pages/HODDashboard";
 import ParentDashboard from "./pages/ParentDashboard";
@@ -45,10 +45,13 @@ import AnnouncementManage from "./common-components-management/AnnouncementManag
 
 import { PwaManager } from "./components/PwaManager";
 
+import BackToTop from "./components/BackToTop";
+
 export default function App() {
   return (
     <BrowserRouter>
       <PwaManager />
+      <BackToTop />
       <Routes>
         {/* Public Routes */}
         <Route
@@ -253,7 +256,7 @@ export default function App() {
     </RoleRoute>
   }
 />
-     </Routes>
+     
 
         <Route
           path="/parent/dashboard"

--- a/collegems-client/src/common-components-management/Students.tsx
+++ b/collegems-client/src/common-components-management/Students.tsx
@@ -18,6 +18,8 @@ import api from "../api/axios";
 import { useNavigate } from "react-router-dom";
 import { useServerDataTable } from "../hooks/useServerDataTable";
 import AdvancedExportButton from "./AdvancedExportButton";
+import EmptyState from "../components/EmptyState";
+import BulkTagModal from "./BulkTagModal";
 import CompareStudentsModal, { type Student as CompareStudent } from "./CompareStudentsModal";
 import StudentTimeline from "./StudentTimeline";
 

--- a/collegems-client/src/components/BackToTop.tsx
+++ b/collegems-client/src/components/BackToTop.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+const BackToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      title="Back to top"
+      className="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg transition-all duration-300 hover:scale-110"
+    >
+      <ArrowUp size={20} />
+    </button>
+  );
+};
+
+export default BackToTop;


### PR DESCRIPTION
## Description
This PR adds a reusable `BackToTop` component that renders a floating 
scroll-to-top button across all pages of the application. The button 
appears after scrolling 300px down and smoothly scrolls back to the top 
on click. It is integrated globally in `App.tsx` using the `ArrowUp` icon 
from `lucide-react` (already a project dependency) — no new packages required.

Also fixed 3 pre-existing build errors introduced from a previous merge:
- Duplicate imports of `TimeTable` and `StudentDashboard` in `App.tsx`
- Misplaced `</Routes>` closing tag in `App.tsx` breaking JSX structure
- Missing imports for `EmptyState` and `BulkTagModal` in `Students.tsx` 
  causing TypeScript TS2304 build errors

## 📸 Screenshots
<img width="1917" height="951" alt="Screenshot 2026-06-22 130233" src="https://github.com/user-attachments/assets/f96bf0c8-ba59-4ba4-9ab0-648d6dea741d" />

Closes #365

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation