### PR TITLE
feat: Add Password Strength Indicator with Auto-Hide Security on Signup Form

### DIFF
--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -8,9 +8,9 @@ import BulkFieldReset from "./hod-components/BulkFieldReset";
 
 import TimeTable from "./user-components/TimeTable";
  import StudentDashboard from "./pages/StudentDashboard";
-import TimeTable from "./user-components/TimeTable";
+//import TimeTable from "./user-components/TimeTable";
 
-import StudentDashboard from "./pages/StudentDashboard";
+//import StudentDashboard from "./pages/StudentDashboard";
 import TeacherDashboard from "./pages/TeacherDashboard";
 import HodDashboard from "./pages/HODDashboard";
 import ParentDashboard from "./pages/ParentDashboard";
@@ -253,7 +253,7 @@ export default function App() {
     </RoleRoute>
   }
 />
-     </Routes>
+     
 
         <Route
           path="/parent/dashboard"

--- a/collegems-client/src/common-components-management/Students.tsx
+++ b/collegems-client/src/common-components-management/Students.tsx
@@ -18,6 +18,8 @@ import api from "../api/axios";
 import { useNavigate } from "react-router-dom";
 import { useServerDataTable } from "../hooks/useServerDataTable";
 import AdvancedExportButton from "./AdvancedExportButton";
+import EmptyState from "../components/EmptyState";
+import BulkTagModal from "./BulkTagModal";
 import CompareStudentsModal, { type Student as CompareStudent } from "./CompareStudentsModal";
 import StudentTimeline from "./StudentTimeline";
 

--- a/collegems-client/src/pages/auth/Register.tsx
+++ b/collegems-client/src/pages/auth/Register.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTheme } from "../../context/ThemeContext";
 import {
@@ -18,11 +18,45 @@ export default function Register() {
   const [error, setError] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [duplicateWarning, setDuplicateWarning] = useState<any>(null);
+  const [passwordStrength, setPasswordStrength] = useState<"" | "Weak" | "Medium" | "Strong">("");
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleChange = (e: any) => {
     setForm({ ...form, [e.target.name]: e.target.value });
     setError("");
   };
+
+    // Add this after handleChange function
+  const getPasswordStrength = (password: string): "" | "Weak" | "Medium" | "Strong" => {
+    if (!password) return "";
+    let score = 0;
+    if (password.length >= 8) score++;
+    if (/[A-Z]/.test(password)) score++;
+    if (/[0-9]/.test(password)) score++;
+    if (/[^A-Za-z0-9]/.test(password)) score++;
+    if (score <= 1) return "Weak";
+    if (score <= 3) return "Medium";
+    return "Strong";
+  };
+
+  const handleTogglePassword = () => {
+    if (!showPassword) {
+      setShowPassword(true);
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = setTimeout(() => {
+        setShowPassword(false);
+      }, 3000);
+    } else {
+      setShowPassword(false);
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    };
+  }, []);
   
   const handleRegister = async () => {
     if (loading) return;
@@ -169,19 +203,63 @@ export default function Register() {
               </div>
             </div>
 
+            
             <div>
-            <label htmlFor="password" className={labelClass}>Password *</label>
-             <div className="relative">
-              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Lock className="h-4 w-4 text-gray-400" /></div>
-                <input id="password" name="password" type={showPassword ? "text" : "password"} value={form.password || ""} onChange={handleChange} className={inputClass} placeholder="••••••••" />
+              <label htmlFor="password" className={labelClass}>Password *</label>
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <Lock className="h-4 w-4 text-gray-400" />
+                </div>
+                <input
+                  id="password"
+                  name="password"
+                  type={showPassword ? "text" : "password"}
+                  value={form.password || ""}
+                  onChange={(e) => {
+                    handleChange(e);
+                    setPasswordStrength(getPasswordStrength(e.target.value));
+                  }}
+                  disabled={loading}
+                  className={`${inputClass} disabled:opacity-50 disabled:cursor-not-allowed`}
+                  placeholder="••••••••"
+                />
                 <button
-                 type="button"
-                 onClick={() => setShowPassword(!showPassword)}
-                 className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
-                 >
-                 {showPassword ? <AiOutlineEyeInvisible size={18} /> : <AiOutlineEye size={18} />}
+                  type="button"
+                  onClick={handleTogglePassword}
+                  disabled={loading}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {showPassword ? <AiOutlineEyeInvisible size={18} /> : <AiOutlineEye size={18} />}
                 </button>
               </div>
+                
+              {/* Password Strength Indicator */}
+              {passwordStrength && (
+                <div className="mt-2">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs text-gray-500 dark:text-gray-400">Password strength:</span>
+                    <span className={`text-xs font-medium ${
+                      passwordStrength === "Weak" ? "text-red-500" :
+                      passwordStrength === "Medium" ? "text-yellow-500" :
+                      "text-green-500"
+                    }`}>
+                      {passwordStrength}
+                    </span>
+                  </div>
+                  <div className="w-full bg-gray-200 dark:bg-gray-600 rounded-full h-1.5">
+                    <div className={`h-1.5 rounded-full transition-all duration-300 ${
+                      passwordStrength === "Weak" ? "w-1/3 bg-red-500" :
+                      passwordStrength === "Medium" ? "w-2/3 bg-yellow-500" :
+                      "w-full bg-green-500"
+                    }`} />
+                  </div>
+                  {showPassword && (
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                      🔒 Password will auto-hide in 3 seconds
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
 
             {/* Student Fields */}


### PR DESCRIPTION
## Description
This PR adds two security enhancements to the Register page password field:

### 1. Password Strength Indicator
A real-time strength meter appears below the password field as the user 
types, evaluating password quality across 4 criteria:
- Length >= 8 characters
- Contains uppercase letter
- Contains number
- Contains special character

Displays one of three states with a colored progress bar:
- 🔴 Weak — score 0-1 (red bar, 1/3 width)
- 🟡 Medium — score 2-3 (yellow bar, 2/3 width)
- 🟢 Strong — score 4 (green bar, full width)

### 2. Auto-Hide Password After 3 Seconds
When the user clicks the eye icon to reveal their password, it 
automatically hides again after 3 seconds for security. A message 
"🔒 Password will auto-hide in 3 seconds" is shown as a reminder.

Implementation uses useRef for the timer (not useState) to avoid 
unnecessary re-renders, with proper cleanup on component unmount 
to prevent memory leaks.

###Screenshot
<img width="1248" height="860" alt="Screenshot 2026-06-22 145257" src="https://github.com/user-attachments/assets/9f8ccc68-4f79-4635-b535-2842d1c918d7" />


Closes #364

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation