### PR TITLE
feat: soft lock student record after result publication

### DIFF
--- a/collegems-server/src/controllers/results.controller.js
+++ b/collegems-server/src/controllers/results.controller.js
@@ -101,6 +101,10 @@ export const publishResult = async (req, res) => {
             resultId: result._id,
             timestamp: new Date()
         });
+        await Student.findByIdAndUpdate(
+          result.studentId,
+          { academicRecordLocked: true }
+        );
     } catch (error) {
         if (error.status === 403) return res.status(403).json({ message: error.message });
         res.status(500).json({ message: "Publish failed" });

--- a/collegems-server/src/controllers/user.controller.js
+++ b/collegems-server/src/controllers/user.controller.js
@@ -55,6 +55,18 @@ export const updateMe = async (req, res) => {
     if (!user) {
       return res.status(404).json({ message: "User not found" });
     }
+   if (
+     user.academicRecordLocked &&
+     (
+       req.body.studentId !== undefined ||
+       req.body.semester !== undefined ||
+       req.body.course !== undefined
+    )
+  ) {
+    return res.status(403).json({
+      message: "Academic record is locked after result publication",
+    });
+  }
 
     if (email && email !== user.email) {
       const existing = await User.findOne({ email });
@@ -312,5 +324,31 @@ export const bulkAssignTags = async (req, res) => {
   } catch (error) {
     console.error("Error in bulkAssignTags:", error);
     res.status(500).json({ message: "Server error assigning tags" });
+  }
+};
+
+export const unlockAcademicRecord = async (req, res) => {
+  try {
+    const user = await User.findByIdAndUpdate(
+      req.params.id,
+      { academicRecordLocked: false },
+      { new: true }
+    );
+
+    if (!user) {
+      return res.status(404).json({
+        message: "User not found",
+      });
+    }
+
+    res.json({
+      message: "Academic record unlocked successfully",
+      user,
+    });
+  } catch (error) {
+    console.error("Unlock academic record error:", error);
+    res.status(500).json({
+      message: "Failed to unlock academic record",
+    });
   }
 };

--- a/collegems-server/src/models/User.model.js
+++ b/collegems-server/src/models/User.model.js
@@ -34,6 +34,10 @@ const userSchema = new mongoose.Schema({
 
   // Student/Alumni-specific fields
   studentId: { type: String },
+  academicRecordLocked: {
+    type: Boolean,
+    default: false,
+  },
   semester: {
     type: String,
     required: function () {

--- a/collegems-server/src/routes/user.routes.js
+++ b/collegems-server/src/routes/user.routes.js
@@ -13,6 +13,7 @@ import {
   getStudentSummary,
   getStudentProfile,
   bulkAssignTags,
+  unlockAcademicRecord,
 } from "../controllers/user.controller.js";
 import { getCleanupSuggestions } from "../services/userCleanup.service.js";
 import { uploadResume } from "../middlewares/upload.middleware.js";
@@ -86,6 +87,12 @@ router.get("/teachers", protect, authorize("hod", "teacher", "student"), async (
 
 // TODO: getCleanupSuggestions is not implemented yet
 // router.get("/cleanup-suggestions", protect, authorize("admin"), getCleanupSuggestions);
+router.put(
+  "/students/:id/unlock",
+  protect,
+  authorize("admin"),
+  unlockAcademicRecord
+);
 
 export default router;
 


### PR DESCRIPTION
## Description

Implemented soft locking of student records after result publication.

### Changes
- Added `academicRecordLocked` field to the User model to persist lock status.
- Automatically locks a student's academic record when results are published.
- Restricted updates to critical academic fields (`studentId`, `semester`, and `course`) once the record is locked.
- Added an admin override endpoint to manually unlock records when corrections are required.

This prevents accidental modification of academic data after results have been published while still allowing administrators to unlock records if necessary.

Fixes #278

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation