### PR TITLE
feat: add data freshness indicator to analytics dashboards

### DIFF
--- a/collegems-client/src/hod-components/Analytics.tsx
+++ b/collegems-client/src/hod-components/Analytics.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { AlertTriangle, TrendingDown, BookOpen, GraduationCap, ChevronRight, Activity } from "lucide-react";
+import { AlertTriangle, Activity } from "lucide-react";
 import api from "../api/axios";
 
 interface AtRiskStudent {
@@ -18,6 +18,29 @@ interface AtRiskStudent {
   recommendedInterventions: string[];
   lastCalculatedAt: string;
 }
+
+const getFreshness = (lastCalculatedAt?: string) => {
+  if (!lastCalculatedAt) {
+    return { isStale: true, relativeTime: "Never" };
+  }
+  const date = new Date(lastCalculatedAt);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (60 * 1000));
+  const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+
+  // Consider stale if older than 24 hours
+  const isStale = diffMs > 24 * 60 * 60 * 1000;
+
+  let relativeTime = "";
+  if (diffMins < 1) relativeTime = "Just now";
+  else if (diffMins < 60) relativeTime = `${diffMins}m ago`;
+  else if (diffHours < 24) relativeTime = `${diffHours}h ago`;
+  else relativeTime = `${diffDays}d ago`;
+
+  return { isStale, relativeTime };
+};
 
 export default function HODAnalytics() {
   const [atRiskStudents, setAtRiskStudents] = useState<AtRiskStudent[]>([]);
@@ -94,53 +117,77 @@ export default function HODAnalytics() {
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Student</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Risk Score</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Predicted Grade</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Last Calculated</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Recommended Interventions</th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
                 </tr>
               </thead>
               <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-                {atRiskStudents.map((record) => (
-                  <tr key={record._id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex items-center">
-                        <div>
-                          <div className="text-sm font-medium text-gray-900 dark:text-white">{record.studentId?.name || "Unknown"}</div>
-                          <div className="text-sm text-gray-500 dark:text-gray-400">{record.studentId?.studentId || record.studentId?.email}</div>
+                {atRiskStudents.map((record) => {
+                  const { isStale, relativeTime } = getFreshness(record.lastCalculatedAt);
+                  return (
+                    <tr 
+                      key={record._id} 
+                      className={`hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors ${
+                        isStale 
+                          ? "bg-amber-50/20 hover:bg-amber-50/40 dark:bg-amber-950/5 dark:hover:bg-amber-950/10" 
+                          : ""
+                      }`}
+                    >
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex items-center">
+                          <div>
+                            <div className="text-sm font-medium text-gray-900 dark:text-white">{record.studentId?.name || "Unknown"}</div>
+                            <div className="text-sm text-gray-500 dark:text-gray-400">{record.studentId?.studentId || record.studentId?.email}</div>
+                          </div>
                         </div>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex items-center gap-2">
-                        <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700 max-w-[100px]">
-                          <div className="bg-red-600 h-2.5 rounded-full" style={{ width: `${Math.round(record.dropoutRiskScore * 100)}%` }}></div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex items-center gap-2">
+                          <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700 max-w-[100px]">
+                            <div className="bg-red-600 h-2.5 rounded-full" style={{ width: `${Math.round(record.dropoutRiskScore * 100)}%` }}></div>
+                          </div>
+                          <span className="text-sm font-semibold text-red-600 dark:text-red-400">
+                            {Math.round(record.dropoutRiskScore * 100)}%
+                          </span>
                         </div>
-                        <span className="text-sm font-semibold text-red-600 dark:text-red-400">
-                          {Math.round(record.dropoutRiskScore * 100)}%
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400">
+                            {record.predictedPerformance}
+                         </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span 
+                          className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold border ${
+                            isStale 
+                              ? "bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-800" 
+                              : "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800"
+                          }`}
+                          title={`Last calculated: ${record.lastCalculatedAt ? new Date(record.lastCalculatedAt).toLocaleString() : "Never"}`}
+                        >
+                          <span className={`w-1.5 h-1.5 rounded-full ${isStale ? "bg-amber-500 animate-pulse" : "bg-green-500"}`} />
+                          {isStale ? `Outdated (${relativeTime})` : `Fresh (${relativeTime})`}
                         </span>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400">
-                          {record.predictedPerformance}
-                       </span>
-                    </td>
-                    <td className="px-6 py-4">
-                      <ul className="list-disc list-inside text-sm text-gray-600 dark:text-gray-400">
-                        {record.recommendedInterventions.map((intervention, idx) => (
-                          <li key={idx}>{intervention}</li>
-                        ))}
-                      </ul>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <button 
-                        onClick={() => assignMentor(record.studentId._id)}
-                        className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                      >
-                        Assign Mentor
-                      </button>
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                      <td className="px-6 py-4">
+                        <ul className="list-disc list-inside text-sm text-gray-600 dark:text-gray-400">
+                          {record.recommendedInterventions.map((intervention, idx) => (
+                            <li key={idx}>{intervention}</li>
+                          ))}
+                        </ul>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <button 
+                          onClick={() => assignMentor(record.studentId._id)}
+                          className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                        >
+                          Assign Mentor
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/collegems-client/src/pages/RiskDashboard.tsx
+++ b/collegems-client/src/pages/RiskDashboard.tsx
@@ -22,6 +22,29 @@ interface AnalyticsData {
   lastCalculatedAt: string;
 }
 
+const getFreshness = (lastCalculatedAt?: string) => {
+  if (!lastCalculatedAt) {
+    return { isStale: true, relativeTime: "Never" };
+  }
+  const date = new Date(lastCalculatedAt);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (60 * 1000));
+  const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+
+  // Consider stale if older than 24 hours (86400000 ms)
+  const isStale = diffMs > 24 * 60 * 60 * 1000;
+
+  let relativeTime = "";
+  if (diffMins < 1) relativeTime = "Just now";
+  else if (diffMins < 60) relativeTime = `${diffMins}m ago`;
+  else if (diffHours < 24) relativeTime = `${diffHours}h ago`;
+  else relativeTime = `${diffDays}d ago`;
+
+  return { isStale, relativeTime };
+};
+
 export default function RiskDashboard() {
   const [analytics, setAnalytics] = useState<AnalyticsData[]>([]);
   const [loading, setLoading] = useState(false);
@@ -162,52 +185,76 @@ export default function RiskDashboard() {
                 <th className="px-6 py-4 font-semibold text-gray-600">Risk Level</th>
                 <th className="px-6 py-4 font-semibold text-gray-600">Risk Score</th>
                 <th className="px-6 py-4 font-semibold text-gray-600">Predicted Grade</th>
+                <th className="px-6 py-4 font-semibold text-gray-600">Last Updated</th>
                 <th className="px-6 py-4 font-semibold text-gray-600">Interventions</th>
               </tr>
             </thead>
             <tbody>
               {analytics.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="px-6 py-8 text-center text-gray-500">
+                  <td colSpan={8} className="px-6 py-8 text-center text-gray-500">
                     No analytics data found for the selected filters.
                   </td>
                 </tr>
               ) : (
-                analytics.map((row) => (
-                  <tr key={row._id} className="border-b hover:bg-gray-50">
-                    <td className="px-6 py-4">{row.studentId?.name || "N/A"}</td>
-                    <td className="px-6 py-4">{row.studentId?.studentId || "N/A"}</td>
-                    <td className="px-6 py-4">
-                      {row.studentId?.course || "N/A"} / {row.studentId?.semester || "N/A"}
-                    </td>
-                    <td className="px-6 py-4">
-                      <span
-                        className={`px-2 py-1 rounded text-xs font-semibold uppercase ${
-                          row.riskLevel === "high"
-                            ? "bg-red-100 text-red-800"
-                            : row.riskLevel === "medium"
-                            ? "bg-yellow-100 text-yellow-800"
-                            : "bg-green-100 text-green-800"
-                        }`}
-                      >
-                        {row.riskLevel}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4">{(row.dropoutRiskScore * 100).toFixed(1)}%</td>
-                    <td className="px-6 py-4 font-bold">{row.predictedPerformance}</td>
-                    <td className="px-6 py-4 whitespace-normal min-w-[200px]">
-                      {row.recommendedInterventions && row.recommendedInterventions.length > 0 ? (
-                        <ul className="list-disc pl-4 text-xs space-y-1 text-gray-700">
-                          {row.recommendedInterventions.map((intervention, idx) => (
-                            <li key={idx}>{intervention}</li>
-                          ))}
-                        </ul>
-                      ) : (
-                        <span className="text-gray-400 text-xs">None</span>
-                      )}
-                    </td>
-                  </tr>
-                ))
+                analytics.map((row) => {
+                  const { isStale, relativeTime } = getFreshness(row.lastCalculatedAt);
+                  return (
+                    <tr 
+                      key={row._id} 
+                      className={`border-b hover:bg-gray-50 transition-colors ${
+                        isStale 
+                          ? "bg-amber-50/30 hover:bg-amber-50/50 dark:bg-amber-950/5 dark:hover:bg-amber-950/10" 
+                          : ""
+                      }`}
+                    >
+                      <td className="px-6 py-4">{row.studentId?.name || "N/A"}</td>
+                      <td className="px-6 py-4">{row.studentId?.studentId || "N/A"}</td>
+                      <td className="px-6 py-4">
+                        {row.studentId?.course || "N/A"} / {row.studentId?.semester || "N/A"}
+                      </td>
+                      <td className="px-6 py-4">
+                        <span
+                          className={`px-2 py-1 rounded text-xs font-semibold uppercase ${
+                            row.riskLevel === "high"
+                              ? "bg-red-100 text-red-800"
+                              : row.riskLevel === "medium"
+                              ? "bg-yellow-100 text-yellow-800"
+                              : "bg-green-100 text-green-800"
+                          }`}
+                        >
+                          {row.riskLevel}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">{(row.dropoutRiskScore * 100).toFixed(1)}%</td>
+                      <td className="px-6 py-4 font-bold">{row.predictedPerformance}</td>
+                      <td className="px-6 py-4">
+                        <span 
+                          className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold border ${
+                            isStale 
+                              ? "bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-800" 
+                              : "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800"
+                          }`}
+                          title={`Last calculated: ${row.lastCalculatedAt ? new Date(row.lastCalculatedAt).toLocaleString() : "Never"}`}
+                        >
+                          <span className={`w-1.5 h-1.5 rounded-full ${isStale ? "bg-amber-500 animate-pulse" : "bg-green-500"}`} />
+                          {isStale ? `Outdated (${relativeTime})` : `Fresh (${relativeTime})`}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-normal min-w-[200px]">
+                        {row.recommendedInterventions && row.recommendedInterventions.length > 0 ? (
+                          <ul className="list-disc pl-4 text-xs space-y-1 text-gray-700">
+                            {row.recommendedInterventions.map((intervention, idx) => (
+                              <li key={idx}>{intervention}</li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <span className="text-gray-400 text-xs">None</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>


### PR DESCRIPTION
## Description

This PR introduces a visual freshness indicator for predictive analytics records in the HOD and Teacher dashboards. It helps users quickly identify when student risk data was last calculated and flags stale records (older than 24 hours) with visual warnings.

**Key Changes:**
- **UI:** Added a new "Last Updated" column to the tables in both `RiskDashboard` and `Analytics` components.
- **Logic:** Created a `getFreshness` utility to calculate record age based on the `lastCalculatedAt` timestamp.
- **UX:** Integrated visual status badges (Fresh/Outdated) with tooltips showing the exact calculation times, and added amber row-level highlighting for outdated prediction entries to improve data transparency.

### Closes #335 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] Updated documentation