### PR TITLE
fix(a11y): add htmlFor/id pairs to Teacher and HOD role form controls

### DIFF
--- a/collegems-client/src/hod-components/FacultyAssignment.tsx
+++ b/collegems-client/src/hod-components/FacultyAssignment.tsx
@@ -557,8 +557,9 @@ const FacultyAssignment: React.FC = () => {
               <div className="grid grid-cols-1 gap-4">
                 {/* Faculty */}
                 <div>
-                  <label className={labelCls}>Faculty Member *</label>
+                  <label htmlFor="fa-faculty" className={labelCls}>Faculty Member *</label>
                   <select
+                    id="fa-faculty"
                     className={selectCls}
                     value={form.faculty}
                     onChange={(e) => setForm((f) => ({ ...f, faculty: e.target.value }))}
@@ -574,8 +575,9 @@ const FacultyAssignment: React.FC = () => {
 
                 {/* Course */}
                 <div>
-                  <label className={labelCls}>Subject / Course *</label>
+                  <label htmlFor="fa-course" className={labelCls}>Subject / Course *</label>
                   <select
+                    id="fa-course"
                     className={selectCls}
                     value={form.course}
                     onChange={(e) => handleCourseChange(e.target.value)}
@@ -592,8 +594,9 @@ const FacultyAssignment: React.FC = () => {
                 {/* Section & Semester */}
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className={labelCls}>Section *</label>
+                    <label htmlFor="fa-section" className={labelCls}>Section *</label>
                     <select
+                      id="fa-section"
                       className={selectCls}
                       value={form.section}
                       onChange={(e) => setForm((f) => ({ ...f, section: e.target.value }))}
@@ -605,8 +608,9 @@ const FacultyAssignment: React.FC = () => {
                     </select>
                   </div>
                   <div>
-                    <label className={labelCls}>Semester *</label>
+                    <label htmlFor="fa-semester" className={labelCls}>Semester *</label>
                     <select
+                      id="fa-semester"
                       className={selectCls}
                       value={form.semester}
                       onChange={(e) => setForm((f) => ({ ...f, semester: e.target.value }))}
@@ -622,8 +626,9 @@ const FacultyAssignment: React.FC = () => {
                 {/* Academic Year & Department */}
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className={labelCls}>Academic Year *</label>
+                    <label htmlFor="fa-academic-year" className={labelCls}>Academic Year *</label>
                     <select
+                      id="fa-academic-year"
                       className={selectCls}
                       value={form.academicYear}
                       onChange={(e) => setForm((f) => ({ ...f, academicYear: e.target.value }))}
@@ -634,8 +639,9 @@ const FacultyAssignment: React.FC = () => {
                     </select>
                   </div>
                   <div>
-                    <label className={labelCls}>Department *</label>
+                    <label htmlFor="fa-department" className={labelCls}>Department *</label>
                     <select
+                      id="fa-department"
                       className={selectCls}
                       value={form.department}
                       onChange={(e) => setForm((f) => ({ ...f, department: e.target.value }))}

--- a/collegems-client/src/hod-components/MentorAssignment.tsx
+++ b/collegems-client/src/hod-components/MentorAssignment.tsx
@@ -56,8 +56,9 @@ export default function MentorAssignment() {
         <h2 className="text-xl font-bold mb-4 dark:text-white flex items-center gap-2"><Users className="w-5 h-5"/> Assign Mentor</h2>
         <form onSubmit={handleAssign} className="flex gap-4 items-end">
           <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Mentor (Teacher)</label>
-            <select 
+            <label htmlFor="mentor-teacher" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Mentor (Teacher)</label>
+            <select
+              id="mentor-teacher"
               className="w-full p-2 border rounded dark:bg-gray-700 dark:text-white dark:border-gray-600"
               value={selectedMentor}
               onChange={e => setSelectedMentor(e.target.value)}
@@ -70,8 +71,9 @@ export default function MentorAssignment() {
             </select>
           </div>
           <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Mentee (Student)</label>
-            <select 
+            <label htmlFor="mentor-mentee" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Mentee (Student)</label>
+            <select
+              id="mentor-mentee"
               className="w-full p-2 border rounded dark:bg-gray-700 dark:text-white dark:border-gray-600"
               value={selectedMentee}
               onChange={e => setSelectedMentee(e.target.value)}

--- a/collegems-client/src/hod-components/ResourceManagement.tsx
+++ b/collegems-client/src/hod-components/ResourceManagement.tsx
@@ -153,12 +153,12 @@ const ResourceManagement: React.FC = () => {
             <h2 className="text-xl font-bold mb-4">Add New Resource</h2>
             <form onSubmit={handleCreateResource} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
-                <input required type="text" value={name} onChange={e => setName(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. Lab 1, Projector A" />
+                <label htmlFor="resource-name" className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                <input id="resource-name" required type="text" value={name} onChange={e => setName(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. Lab 1, Projector A" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Type</label>
-                <select value={type} onChange={e => setType(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500">
+                <label htmlFor="resource-type" className="block text-sm font-medium text-gray-700 mb-1">Type</label>
+                <select id="resource-type" value={type} onChange={e => setType(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500">
                   <option value="classroom">Classroom</option>
                   <option value="lab">Lab</option>
                   <option value="seminar_hall">Seminar Hall</option>
@@ -168,24 +168,24 @@ const ResourceManagement: React.FC = () => {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Capacity</label>
-                  <input type="number" min="0" value={capacity} onChange={e => setCapacity(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. 60" />
+                  <label htmlFor="resource-capacity" className="block text-sm font-medium text-gray-700 mb-1">Capacity</label>
+                  <input id="resource-capacity" type="number" min="0" value={capacity} onChange={e => setCapacity(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. 60" />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
-                  <select value={status} onChange={e => setStatus(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500">
+                  <label htmlFor="resource-status" className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                  <select id="resource-status" value={status} onChange={e => setStatus(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500">
                     <option value="active">Active</option>
                     <option value="maintenance">Maintenance</option>
                   </select>
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Location / Room Number</label>
-                <input type="text" value={location} onChange={e => setLocation(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. Building A, Floor 2" />
+                <label htmlFor="resource-location" className="block text-sm font-medium text-gray-700 mb-1">Location / Room Number</label>
+                <input id="resource-location" type="text" value={location} onChange={e => setLocation(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. Building A, Floor 2" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Features (comma separated)</label>
-                <input type="text" value={features} onChange={e => setFeatures(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. AC, Whiteboard, Smart TV" />
+                <label htmlFor="resource-features" className="block text-sm font-medium text-gray-700 mb-1">Features (comma separated)</label>
+                <input id="resource-features" type="text" value={features} onChange={e => setFeatures(e.target.value)} className="w-full border p-2 rounded focus:ring-blue-500 focus:border-blue-500" placeholder="e.g. AC, Whiteboard, Smart TV" />
               </div>
               <div className="flex justify-end gap-3 mt-6 pt-4 border-t">
                 <button type="button" onClick={() => setShowModal(false)} className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded">Cancel</button>

--- a/collegems-client/src/hod-components/SystemLogsDashboard.tsx
+++ b/collegems-client/src/hod-components/SystemLogsDashboard.tsx
@@ -93,8 +93,9 @@ export default function SystemLogsDashboard() {
         <h2 className="text-lg font-semibold mb-4">Trace Filters</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Log Level</label>
+            <label htmlFor="log-level" className="block text-sm font-medium text-gray-700 mb-1">Log Level</label>
             <select
+              id="log-level"
               className="w-full border p-2 rounded"
               value={level}
               onChange={(e) => setLevel(e.target.value)}
@@ -106,8 +107,9 @@ export default function SystemLogsDashboard() {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Correlation ID (Trace ID)</label>
+            <label htmlFor="log-correlation-id" className="block text-sm font-medium text-gray-700 mb-1">Correlation ID (Trace ID)</label>
             <input
+              id="log-correlation-id"
               type="text"
               placeholder="e.g. 550e8400-e29b..."
               className="w-full border p-2 rounded"
@@ -116,8 +118,9 @@ export default function SystemLogsDashboard() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Service</label>
+            <label htmlFor="log-service" className="block text-sm font-medium text-gray-700 mb-1">Service</label>
             <select
+              id="log-service"
               className="w-full border p-2 rounded"
               value={service}
               onChange={(e) => setService(e.target.value)}

--- a/collegems-client/src/teacher-components/PlagiarismChecker.tsx
+++ b/collegems-client/src/teacher-components/PlagiarismChecker.tsx
@@ -257,10 +257,11 @@ export default function PlagiarismChecker() {
       <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
         <div className="grid grid-cols-1 sm:grid-cols-[2fr_1fr_auto] gap-3">
           <div>
-            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label htmlFor="plagiarism-assignment" className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
               Assignment
             </label>
             <select
+              id="plagiarism-assignment"
               className={inputCls}
               value={selectedAssignment}
               onChange={(e) => setSelectedAssignment(e.target.value)}
@@ -275,12 +276,13 @@ export default function PlagiarismChecker() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label htmlFor="plagiarism-threshold" className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
               Flag Threshold (%)
             </label>
             <div className="relative">
               <Sliders className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
               <input
+                id="plagiarism-threshold"
                 type="number"
                 min={10}
                 max={100}


### PR DESCRIPTION
Add programmatic label associations (WCAG 2.2 SC 1.3.1 Level A) to five Teacher and HOD components that were missing them:

- SystemLogsDashboard.tsx: Log Level select, Correlation ID input, Service select
- ResourceManagement.tsx: Name, Type, Capacity, Status, Location, Features fields
- MentorAssignment.tsx: Mentor (Teacher) select, Mentee (Student) select
- FacultyAssignment.tsx: Faculty, Course, Section, Semester, Academic Year, Department
- PlagiarismChecker.tsx: Assignment select, Flag Threshold input

Fixes: label elements now have htmlFor and matching controls have id so screen readers can announce field names when a user focuses a control.

Closes #429

## Description

Please explain what this PR changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation
