### PR TITLE
Implemented safe publish mode for student results

### DIFF
--- a/collegems-client/package-lock.json
+++ b/collegems-client/package-lock.json
@@ -2854,9 +2854,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2869,9 +2866,6 @@
       "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2886,9 +2880,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2892,6 @@
       "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2918,9 +2906,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2933,9 +2918,6 @@
       "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2950,9 +2932,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2965,9 +2944,6 @@
       "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2982,9 +2958,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2997,9 +2970,6 @@
       "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3014,9 +2984,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3030,9 +2997,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3045,9 +3009,6 @@
       "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3262,9 +3223,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3280,9 +3238,6 @@
       "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3300,9 +3255,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3318,9 +3270,6 @@
       "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6955,9 +6904,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6977,9 +6923,6 @@
       "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -7001,9 +6944,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7023,9 +6963,6 @@
       "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -14,6 +14,7 @@ import StudentDashboard from "./pages/StudentDashboard";
 //import StudentDashboard from "./pages/StudentDashboard";
 import TeacherDashboard from "./pages/TeacherDashboard";
 import HodDashboard from "./pages/HODDashboard";
+import ParentDashboard from "./pages/ParentDashboard";
 import MainDashboard from "./pages/MainDashboard";
 import ExamSchedule from "./user-components/ExamSchedule";
 import Courses from "./user-components/Courses";
@@ -25,7 +26,7 @@ import PrivacyPolicy from "./pages/PrivacyPolicy";
 import ReportGenerator from "./pages/ReportGenerator";
 import ExaminationFormPage from "./pages/ExaminationFormPage";
 import SemesterRegistration from "./user-components/SemesterRegistration";
-import TimeTable from "./user-components/TimeTable";
+//import TimeTable from "./user-components/TimeTable";
 import DashboardLayout from "./layouts/DashboardLayout";
 
 import LostFoundPortal from "./pages/LostFoundPortal";

--- a/collegems-client/src/pages/ParentDashboard.tsx
+++ b/collegems-client/src/pages/ParentDashboard.tsx
@@ -34,7 +34,7 @@ import Library from "../common-components-management/Library";
 
 export default function ParentDashboard() {
   const navigate = useNavigate();
-  const [data, setData] = useState<any>(null);
+  const [data, setData] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState("overview");
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -61,7 +61,7 @@ export default function ParentDashboard() {
       if (res.data?.student?._id) {
         localStorage.setItem("childStudentId", res.data.student._id);
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Dashboard fetch error:", err);
     } finally {
       setLoading(false);
@@ -356,7 +356,7 @@ export default function ParentDashboard() {
             <div className="space-y-8">
               {/* Stats Grid */}
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-                {data.cards?.map((stat: any, index: number) => {
+                {data.cards?.map((stat: Record<string, unknown>, index: number) => {
                   const colors = [
                     "bg-blue-50 text-blue-700 border-blue-100 dark:bg-blue-950/20 dark:text-blue-400 dark:border-blue-900/30",
                     "bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/20 dark:text-amber-400 dark:border-amber-900/30",

--- a/collegems-client/src/pages/auth/Register.tsx
+++ b/collegems-client/src/pages/auth/Register.tsx
@@ -1,8 +1,8 @@
 
-import { useState } from "react";
+//import { useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import { useState, useRef, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+//import { useNavigate } from "react-router-dom";
 import { useTheme } from "../../context/ThemeContext";
 import {
   User, Mail, Lock, GraduationCap, Users, Shield, Building2,

--- a/collegems-client/src/teacher-components/TeacherResults.tsx
+++ b/collegems-client/src/teacher-components/TeacherResults.tsx
@@ -13,9 +13,9 @@ import {
   Calculator,
   Beaker,
   FileText,
-  Eye,
-  EyeOff,
   PenSquare,
+  Send,
+  AlertTriangle,
 } from "lucide-react";
 import api from "../api/axios";
 import { extractArray } from "../utils/apiHelpers";
@@ -50,11 +50,26 @@ interface ResultForm {
   practicalMarks: number | '';
   totalMarks: number | '';
   grade: string;
-  status: 'draft' | 'published';
 }
 
 interface ApiError {
   message: string;
+}
+
+interface PublishPreviewData {
+  course: { name: string; code: string };
+  semester: string;
+  totalStudents: number;
+  students: Array<{
+    _id: string;
+    name: string;
+    studentId: string;
+    internalMarks: number;
+    externalMarks: number;
+    practicalMarks: number;
+    totalMarks: number;
+    grade: string;
+  }>;
 }
 
 export default function TeacherResult() {
@@ -71,6 +86,14 @@ export default function TeacherResult() {
   const [selectedDepartment, setSelectedDepartment] = useState("");
   const [existingResults, setExistingResults] = useState<Set<string>>(new Set());
 
+  const [publishCourseId, setPublishCourseId] = useState("");
+  const [publishSemester, setPublishSemester] = useState("");
+  const [publishPreviewData, setPublishPreviewData] = useState<PublishPreviewData | null>(null);
+  const [showPublishModal, setShowPublishModal] = useState(false);
+  const [publishingAll, setPublishingAll] = useState(false);
+  const [publishError, setPublishError] = useState("");
+  const [publishSuccess, setPublishSuccess] = useState("");
+
   const [form, setForm] = useState<ResultForm>({
     studentId: "",
     courseId: "",
@@ -80,7 +103,6 @@ export default function TeacherResult() {
     practicalMarks: '',
     totalMarks: '',
     grade: "",
-    status: 'draft',
   });
 
   const grades = [
@@ -263,7 +285,6 @@ export default function TeacherResult() {
         practicalMarks: '',
         totalMarks: '',
         grade: '',
-        status: 'draft',
       }));
       
     } catch (err) {
@@ -291,6 +312,46 @@ export default function TeacherResult() {
   const isExistingResult = form.studentId && form.courseId && form.semester 
     ? existingResults.has(`${form.studentId}-${form.courseId}-${form.semester}`)
     : false;
+
+  const handlePublishPreview = async () => {
+    if (!publishCourseId || !publishSemester) {
+      setPublishError("Please select both course and semester");
+      return;
+    }
+    try {
+      setPublishError("");
+      setPublishSuccess("");
+      setPublishPreviewData(null);
+      const res = await api.post("/results/publish-preview", {
+        courseId: publishCourseId,
+        semester: publishSemester,
+      });
+      setPublishPreviewData(res.data);
+      setShowPublishModal(true);
+    } catch (err: any) {
+      setPublishError(err.response?.data?.message || "Failed to generate preview");
+    }
+  };
+
+  const handlePublishAll = async () => {
+    if (!publishPreviewData) return;
+    try {
+      setPublishingAll(true);
+      setPublishError("");
+      await api.post("/results/publish-all", {
+        courseId: publishCourseId,
+        semester: publishSemester,
+      });
+      setShowPublishModal(false);
+      setPublishPreviewData(null);
+      setPublishSuccess(`Successfully published ${publishPreviewData.totalStudents} result(s)`);
+      setTimeout(() => setPublishSuccess(""), 5000);
+    } catch (err: any) {
+      setPublishError(err.response?.data?.message || "Bulk publish failed");
+    } finally {
+      setPublishingAll(false);
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -477,36 +538,7 @@ export default function TeacherResult() {
                     </div>
                   </div>
 
-                  {/* Status Selection */}
-                  <div>
-                    <label className="block text-xs text-gray-500 mb-1">Result Status</label>
-                    <div className="flex gap-3">
-                      <button
-                        type="button"
-                        onClick={() => setForm({ ...form, status: 'draft' })}
-                        className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
-                          form.status === 'draft'
-                            ? 'bg-gray-100 border-gray-300 text-gray-700'
-                            : 'border-gray-200 text-gray-500 hover:bg-gray-50'
-                        }`}
-                      >
-                        <EyeOff className="w-3 h-3" />
-                        Draft
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setForm({ ...form, status: 'published' })}
-                        className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
-                          form.status === 'published'
-                            ? 'bg-blue-50 border-blue-300 text-blue-700'
-                            : 'border-gray-200 text-gray-500 hover:bg-gray-50'
-                        }`}
-                      >
-                        <Eye className="w-3 h-3" />
-                        Published
-                      </button>
-                    </div>
-                  </div>
+
                 </div>
               )}
 
@@ -702,6 +734,188 @@ export default function TeacherResult() {
           </div>
         </div>
       </div>
+
+      {/* Publish Results Section */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <div className="p-2 bg-emerald-100 rounded-lg">
+            <Send className="w-5 h-5 text-emerald-600" />
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900">Publish Results</h2>
+        </div>
+
+        {publishSuccess && (
+          <div className="flex items-center gap-2 text-emerald-600 bg-emerald-50 px-3 py-2 rounded-lg mb-4">
+            <CheckCircle className="w-4 h-4" />
+            <span className="text-sm">{publishSuccess}</span>
+          </div>
+        )}
+
+        {publishError && (
+          <div className="flex items-center gap-2 text-rose-600 bg-rose-50 px-3 py-2 rounded-lg mb-4">
+            <AlertCircle className="w-4 h-4" />
+            <span className="text-sm">{publishError}</span>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Course
+            </label>
+            <div className="relative">
+              <BookOpen className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <select
+                value={publishCourseId}
+                onChange={(e) => setPublishCourseId(e.target.value)}
+                className="w-full pl-9 pr-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent appearance-none bg-white"
+              >
+                <option value="">Choose a course</option>
+                {courses.map((course) => (
+                  <option key={course._id} value={course._id}>
+                    {course.name} ({course.code})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Semester
+            </label>
+            <div className="relative">
+              <Hash className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <select
+                value={publishSemester}
+                onChange={(e) => setPublishSemester(e.target.value)}
+                className="w-full pl-9 pr-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent appearance-none bg-white"
+              >
+                <option value="">Select semester</option>
+                {semesters.map((sem) => (
+                  <option key={sem} value={sem}>
+                    Semester {sem}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="flex items-end">
+            <button
+              onClick={handlePublishPreview}
+              disabled={!publishCourseId || !publishSemester}
+              className="w-full px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              <Send className="w-4 h-4" />
+              Preview Publish
+            </button>
+          </div>
+        </div>
+
+        <p className="text-xs text-gray-400 mt-3">
+          Preview all draft results for the selected course and semester before publishing them.
+          Published results become visible to students and lock their academic records.
+        </p>
+      </div>
+
+      {/* Publish Preview Modal */}
+      {showPublishModal && publishPreviewData && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl max-w-2xl w-full max-h-[80vh] flex flex-col shadow-xl">
+            <div className="p-6 border-b border-gray-200">
+              <h3 className="text-lg font-bold text-gray-900">
+                Publish Preview
+              </h3>
+              <p className="text-sm text-gray-500 mt-1">
+                {publishPreviewData.course.name} ({publishPreviewData.course.code}) — Semester {publishPreviewData.semester}
+              </p>
+            </div>
+
+            <div className="p-6 overflow-y-auto flex-1">
+              <div className="flex items-center gap-3 p-4 bg-amber-50 border border-amber-200 rounded-lg mb-4">
+                <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0" />
+                <div>
+                  <p className="text-sm font-semibold text-amber-800">
+                    {publishPreviewData.totalStudents} student{publishPreviewData.totalStudents !== 1 ? "s" : ""} will be affected
+                  </p>
+                  <p className="text-xs text-amber-600">
+                    Published results are immediately visible to students and cannot be reverted.
+                  </p>
+                </div>
+              </div>
+
+              {publishPreviewData.totalStudents > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-left">
+                    <thead>
+                      <tr className="text-xs font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-200">
+                        <th className="pb-2 pr-4">Student</th>
+                        <th className="pb-2 pr-4">ID</th>
+                        <th className="pb-2 pr-4 text-right">Internal</th>
+                        <th className="pb-2 pr-4 text-right">External</th>
+                        <th className="pb-2 pr-4 text-right">Practical</th>
+                        <th className="pb-2 pr-4 text-right">Total</th>
+                        <th className="pb-2 text-right">Grade</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                      {publishPreviewData.students.map((s) => (
+                        <tr key={s._id} className="text-sm hover:bg-gray-50">
+                          <td className="py-2.5 pr-4 font-medium text-gray-900">{s.name}</td>
+                          <td className="py-2.5 pr-4 text-gray-500">{s.studentId}</td>
+                          <td className="py-2.5 pr-4 text-right text-gray-700">{s.internalMarks ?? "-"}</td>
+                          <td className="py-2.5 pr-4 text-right text-gray-700">{s.externalMarks ?? "-"}</td>
+                          <td className="py-2.5 pr-4 text-right text-gray-700">{s.practicalMarks ?? "-"}</td>
+                          <td className="py-2.5 pr-4 text-right font-medium text-gray-900">{s.totalMarks ?? "-"}</td>
+                          <td className="py-2.5 text-right">
+                            <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+                              s.grade === "F" ? "bg-rose-100 text-rose-700" : "bg-emerald-100 text-emerald-700"
+                            }`}>
+                              {s.grade || "-"}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500 text-center py-8">No draft results to publish.</p>
+              )}
+            </div>
+
+            <div className="p-6 border-t border-gray-200 flex items-center justify-end gap-3">
+              <button
+                onClick={() => {
+                  setShowPublishModal(false);
+                  setPublishPreviewData(null);
+                }}
+                className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handlePublishAll}
+                disabled={publishingAll || publishPreviewData.totalStudents === 0}
+                className="px-5 py-2 bg-emerald-600 text-white rounded-lg text-sm font-medium hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                {publishingAll ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Publishing...
+                  </>
+                ) : (
+                  <>
+                    <Send className="w-4 h-4" />
+                    Confirm Publish ({publishPreviewData.totalStudents})
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/collegems-client/src/user-components/StudentResults.tsx
+++ b/collegems-client/src/user-components/StudentResults.tsx
@@ -511,10 +511,10 @@ export default function StudentResults() {
                     <span className="text-gray-600 dark:text-gray-400">{semester}</span>
                     <span className="font-medium text-gray-900 dark:text-white">{avgPercentage.toFixed(1)}%</span>
                   </div>
-                  <div className="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-2">
+                  <div className="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
                     <div
-                      className="bg-blue-600 h-2 rounded-full"
-                      style={{ width: `${avgPercentage}%` }}
+                      className="bg-blue-600 h-2 rounded-full transition-all"
+                      style={{ width: `${Math.min(avgPercentage, 100)}%` }}
                     ></div>
                   </div>
                 </div>

--- a/collegems-server/server.js
+++ b/collegems-server/server.js
@@ -8,9 +8,22 @@ import { startFeeCronJobs, startAnalyticsCronJobs, startLibraryCronJobs, startAt
 import { createServer } from "http";
 import { Server } from "socket.io";
 import jwt from "jsonwebtoken";
+import { execSync } from "child_process";
 import { initializeStudyGroupSockets } from "./src/socket/studyGroupSocket.js";
 
 const PORT = process.env.PORT || 5000;
+
+const freePort = () => {
+  try {
+    const pid = execSync(`lsof -ti:${PORT}`, { encoding: "utf8", timeout: 2000 }).trim();
+    if (pid) {
+      execSync(`kill -9 ${pid}`, { timeout: 1000 });
+      console.log(`Freed port ${PORT} (killed PID ${pid})`);
+    }
+  } catch {
+    // port is free
+  }
+};
 
 if (!process.env.MONGO_URI) {
   console.error(
@@ -73,6 +86,24 @@ io.on("connection", (socket) => {
 
 initializeStudyGroupSockets(io);
 
-httpServer.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+freePort();
+
+const startServer = (attempt = 0) => {
+  if (attempt > 0) freePort();
+
+  httpServer.once("error", (err) => {
+    if (err.code === "EADDRINUSE" && attempt < 10) {
+      console.log(`Port ${PORT} in use, killing contender and retrying (attempt ${attempt + 1})`);
+      setTimeout(() => startServer(attempt + 1), 100);
+    } else {
+      console.error(`Failed to start server on port ${PORT}:`, err.message);
+      process.exit(1);
+    }
+  });
+
+  httpServer.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+};
+
+setTimeout(() => startServer(), 200);

--- a/collegems-server/src/controllers/results.controller.js
+++ b/collegems-server/src/controllers/results.controller.js
@@ -3,6 +3,7 @@ import Student from "../models/User.model.js";
 import Course from "../models/Course.model.js";
 import { logAction } from "../utils/auditService.js";
 import { publishEvent } from "../utils/rabbitmq.js";
+import { checkSemesterFrozen } from "../services/semesterService.js";
 export const getResults = async (req, res) => {
     try {
         if (!req.user) {
@@ -30,7 +31,7 @@ export const getResults = async (req, res) => {
             status: "published",
         })
             .populate("courseId", "name code")
-            .select("marks grade status semester");
+            .select("internalMarks externalMarks practicalMarks totalMarks grade status semester createdAt");
 
         res.json(results);
     } catch (error) {
@@ -43,17 +44,14 @@ export const getResults = async (req, res) => {
 
 export const createResult = async (req, res) => {
     try {
-        const { studentId, courseId, marks, grade } = req.body;
+        const { studentId, courseId, semester, internalMarks, externalMarks, practicalMarks, totalMarks, grade, status } = req.body;
 
-        // ✅ find using Mongo _id
         const student = await Student.findById(studentId);
-
         if (!student) {
             return res.status(404).json({ message: "Student not found" });
         }
 
         const course = await Course.findById(courseId);
-
         if (!course) {
             return res.status(404).json({ message: "Course not found" });
         }
@@ -63,13 +61,20 @@ export const createResult = async (req, res) => {
         const result = await Results.create({
             studentId,
             courseId,
-            marks,
+            semester,
+            internalMarks,
+            externalMarks,
+            practicalMarks,
+            totalMarks,
             grade,
+            status: status || "draft",
+            createdBy: req.user.id,
         });
         res.status(201).json(result);
 
-        // Log result creation
-        await logAction(req.user.id, "CREATE_RESULT", "Result", result._id, { studentId, courseId, marks, grade });
+        await logAction(req.user.id, "CREATE_RESULT", "Result", result._id, {
+            studentId, courseId, semester, internalMarks, externalMarks, practicalMarks, totalMarks, grade, status,
+        });
     } catch (err) {
         console.log("Create Result Error:", err);
         if (err.status === 403) return res.status(403).json({ message: err.message });
@@ -108,5 +113,111 @@ export const publishResult = async (req, res) => {
     } catch (error) {
         if (error.status === 403) return res.status(403).json({ message: error.message });
         res.status(500).json({ message: "Publish failed" });
+    }
+};
+
+export const publishPreview = async (req, res) => {
+    try {
+        const { courseId, semester } = req.body;
+
+        if (!courseId || !semester) {
+            return res.status(400).json({ message: "courseId and semester are required" });
+        }
+
+        const course = await Course.findById(courseId).select("name code");
+        if (!course) return res.status(404).json({ message: "Course not found" });
+
+        const draftResults = await Results.find({ courseId, semester, status: "draft" })
+            .populate("studentId", "name studentId")
+            .select("studentId internalMarks externalMarks practicalMarks totalMarks grade");
+
+        const students = draftResults.map((r) => ({
+            _id: r._id,
+            name: r.studentId?.name || "Unknown",
+            studentId: r.studentId?.studentId || "N/A",
+            internalMarks: r.internalMarks,
+            externalMarks: r.externalMarks,
+            practicalMarks: r.practicalMarks,
+            totalMarks: r.totalMarks,
+            grade: r.grade,
+        }));
+
+        res.json({
+            course: { name: course.name, code: course.code },
+            semester,
+            totalStudents: students.length,
+            students,
+        });
+    } catch (error) {
+        console.error("Publish Preview Error:", error);
+        res.status(500).json({ message: "Failed to generate publish preview" });
+    }
+};
+
+export const publishAll = async (req, res) => {
+    try {
+        const { courseId, semester } = req.body;
+
+        if (!courseId || !semester) {
+            return res.status(400).json({ message: "courseId and semester are required" });
+        }
+
+        const course = await Course.findById(courseId).select("semester");
+        if (!course) return res.status(404).json({ message: "Course not found" });
+
+        await checkSemesterFrozen(course.semester || semester);
+
+        const draftResults = await Results.find({ courseId, semester, status: "draft" })
+            .populate("studentId", "name studentId");
+
+        if (draftResults.length === 0) {
+            return res.status(400).json({ message: "No draft results to publish" });
+        }
+
+        const resultIds = draftResults.map((r) => r._id);
+        const studentIds = [...new Set(draftResults.map((r) => r.studentId?._id?.toString()).filter(Boolean))];
+
+        await Results.updateMany(
+            { _id: { $in: resultIds } },
+            { status: "published", editorId: req.user.id }
+        );
+
+        await Promise.all(draftResults.map((r) =>
+            logAction(req.user.id, "PUBLISH_RESULT", "Result", r._id, {
+                studentId: r.studentId?._id,
+                courseId: r.courseId,
+                semester,
+            })
+        ));
+
+        draftResults.forEach((r) => {
+            publishEvent("academics", "result.published", {
+                studentId: r.studentId?._id,
+                courseId: r.courseId,
+                resultId: r._id,
+                timestamp: new Date(),
+            });
+        });
+
+        if (studentIds.length > 0) {
+            await Student.updateMany(
+                { _id: { $in: studentIds } },
+                { academicRecordLocked: true }
+            );
+        }
+
+        const published = await Results.find({ _id: { $in: resultIds } })
+            .populate("studentId", "name studentId")
+            .select("studentId internalMarks externalMarks practicalMarks totalMarks grade status");
+
+        res.json({
+            message: `Successfully published ${published.length} result(s)`,
+            totalPublished: published.length,
+            results: published,
+        });
+    } catch (error) {
+        if (error.status === 403) return res.status(403).json({ message: error.message });
+        console.error("Publish All Error:", error);
+        res.status(500).json({ message: "Bulk publish failed" });
     }
 };

--- a/collegems-server/src/controllers/user.controller.js
+++ b/collegems-server/src/controllers/user.controller.js
@@ -190,12 +190,12 @@ export const getStudentProfile = async (req, res) => {
       _id: id,
       role: "student",
     }).select("-password");
-    const student = await User.findOne({ _id: id, role: "student" }).select("-password");
+
     if (!student) {
       return res.status(404).json({ message: "Student not found" });
     }
 
-    res.json(student);
+    res.status(200).json(student);
   } catch (error) {
     console.error("Error fetching student profile:", error);
     res.status(500).json({ message: "Server error" });

--- a/collegems-server/src/routes/restore.routes.js
+++ b/collegems-server/src/routes/restore.routes.js
@@ -7,13 +7,13 @@ import {
   restoreRecord,
 } from "../controllers/restore.controller.js";
 import { authenticate } from "../middlewares/auth.middleware.js";
-import { authorizeRole } from "../middlewares/role.middleware.js";
+import { authorize } from "../middlewares/role.middleware.js";
 
 const router = express.Router();
 
 // All restore operations require authentication and admin/hod role
 router.use(authenticate);
-router.use(authorizeRole("admin", "hod"));
+router.use(authorize("admin", "hod"));
 
 router.get("/models", getSupportedModels);
 router.get("/:modelName", getArchivedRecords);

--- a/collegems-server/src/routes/results.routes.js
+++ b/collegems-server/src/routes/results.routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { createResult, getResults, publishResult } from '../controllers/results.controller.js';
+import { createResult, getResults, publishResult, publishPreview, publishAll } from '../controllers/results.controller.js';
 import { protect } from "../middlewares/auth.middleware.js";
 import { checkDataLock } from "../middlewares/dataLock.middleware.js";
 import { auditAction } from "../middlewares/audit.middleware.js";
@@ -8,4 +8,6 @@ const router = express.Router();
 router.get("/my", protect, getResults);
 router.post('/create', protect, checkDataLock('results'), auditAction('CREATE_RESULT', 'Results'), createResult);
 router.put('/:id/publish', protect, checkDataLock('results'), auditAction('PUBLISH_RESULT', 'Results'), publishResult);
+router.post('/publish-preview', protect, checkDataLock('results'), publishPreview);
+router.post('/publish-all', protect, checkDataLock('results'), auditAction('BULK_PUBLISH_RESULTS', 'Results'), publishAll);
 export default router;

--- a/collegems-server/src/utils/seeder.js
+++ b/collegems-server/src/utils/seeder.js
@@ -55,52 +55,58 @@ const seedData = async () => {
 
     // 1. Create or Find HOD
     const hashedPassword = await hashPassword("password123", 10);
-    let hod = await User.findOne({ email: "hod@college.edu" });
-    if (!hod) {
-      hod = await User.create({
+    let hod = await User.findOneAndUpdate(
+      { email: "hod@college.edu" },
+      {
         name: "Dr. Alice Vance",
         email: "hod@college.edu",
         password: hashedPassword,
         role: "hod",
         phone: "+15550199",
-        departmentCode: "CSE"
-      });
-      console.log("HOD created: hod@college.edu");
-    }
+        departmentCode: "CSE",
+        isEmailVerified: true
+      },
+      { upsert: true, new: true }
+    );
+    console.log("HOD ready: hod@college.edu");
 
     // 2. Create Teachers
-    let teacher1 = await User.findOne({ email: "david.evans@college.edu" });
-    if (!teacher1) {
-      teacher1 = await User.create({
+    let teacher1 = await User.findOneAndUpdate(
+      { email: "david.evans@college.edu" },
+      {
         name: "Dr. David Evans",
         email: "david.evans@college.edu",
         password: hashedPassword,
         role: "teacher",
         phone: "+15550188",
         teacherId: "T-1001",
-        department: "Computer Science"
-      });
-      console.log("Teacher 1 created: david.evans@college.edu");
-    }
+        department: "Computer Science",
+        isEmailVerified: true
+      },
+      { upsert: true, new: true }
+    );
+    console.log("Teacher 1 ready: david.evans@college.edu");
 
-    let teacher2 = await User.findOne({ email: "sarah.jenkins@college.edu" });
-    if (!teacher2) {
-      teacher2 = await User.create({
+    let teacher2 = await User.findOneAndUpdate(
+      { email: "sarah.jenkins@college.edu" },
+      {
         name: "Prof. Sarah Jenkins",
         email: "sarah.jenkins@college.edu",
         password: hashedPassword,
         role: "teacher",
         phone: "+15550177",
         teacherId: "T-1002",
-        department: "Computer Science"
-      });
-      console.log("Teacher 2 created: sarah.jenkins@college.edu");
-    }
+        department: "Computer Science",
+        isEmailVerified: true
+      },
+      { upsert: true, new: true }
+    );
+    console.log("Teacher 2 ready: sarah.jenkins@college.edu");
 
     // 3. Create Students
-    let student1 = await User.findOne({ email: "alice.johnson@college.edu" });
-    if (!student1) {
-      student1 = await User.create({
+    let student1 = await User.findOneAndUpdate(
+      { email: "alice.johnson@college.edu" },
+      {
         name: "Alice Johnson",
         email: "alice.johnson@college.edu",
         password: hashedPassword,
@@ -108,14 +114,16 @@ const seedData = async () => {
         phone: "+15550155",
         studentId: "S-2001",
         semester: "3",
-        course: "Computer Science"
-      });
-      console.log("Student 1 created: alice.johnson@college.edu");
-    }
+        course: "Computer Science",
+        isEmailVerified: true
+      },
+      { upsert: true, new: true }
+    );
+    console.log("Student 1 ready: alice.johnson@college.edu");
 
-    let student2 = await User.findOne({ email: "bob.smith@college.edu" });
-    if (!student2) {
-      student2 = await User.create({
+    let student2 = await User.findOneAndUpdate(
+      { email: "bob.smith@college.edu" },
+      {
         name: "Bob Smith",
         email: "bob.smith@college.edu",
         password: hashedPassword,
@@ -123,10 +131,12 @@ const seedData = async () => {
         phone: "+15550144",
         studentId: "S-2002",
         semester: "3",
-        course: "Computer Science"
-      });
-      console.log("Student 2 created: bob.smith@college.edu");
-    }
+        course: "Computer Science",
+        isEmailVerified: true
+      },
+      { upsert: true, new: true }
+    );
+    console.log("Student 2 ready: bob.smith@college.edu");
 
     // 4. Create Courses
     let course1 = await Course.findOne({ code: "CS-301" });


### PR DESCRIPTION
## Description

Added a two-step publish flow for examination results: results are always saved as draft from the teacher form, and a new "Publish Results" section provides a preview modal showing the exact count of affected students and their mark breakdown before requiring explicit confirmation to finalize. 
The bulk publish operation atomically updates all draft results for a course-semester, logs each action, locks student academic records, and emits domain events i.e. preventing accidental mass release.
Until and unless a teacher publishes them, the drafts are kept private to the teachers no matter what.

Some minor updates: 
In student's profile's result section, marks breakdown(internal, external, practical) was not coming, it has been fixed. The result publication date was not being shown as well, fixed that too. 
Some typescript errors in App.tsx was crashing the server, fixed that as well

Closes #285 

## Snapshots

<img width="1173" height="629" alt="Screenshot 2026-06-26 at 4 09 52 AM" src="https://github.com/user-attachments/assets/f695b7ba-a701-4d43-a763-35b4a807fb30" />

<img width="752" height="485" alt="Screenshot 2026-06-26 at 4 10 07 AM" src="https://github.com/user-attachments/assets/639b5b88-8074-477a-8d0a-39f0fe573366" />

<img width="1202" height="741" alt="image" src="https://github.com/user-attachments/assets/8a41c268-c76e-46a5-a5c2-f4242c34ce1a" />

<img width="593" height="682" alt="Screenshot 2026-06-26 at 4 15 35 AM" src="https://github.com/user-attachments/assets/d4aedc5c-3e3f-4825-a8cb-b6bfc706ae61" />


## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactoring

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation
