### PR TITLE
FEATURE(auth): enforce strong password validation during registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ SCMS is structured around role-based modules, ensuring that every user has a tai
 - **Secure JWT Authentication**: Industry-standard access token structure stored in global state.
 - **Role-Based Access Control (RBAC)**: Fine-grained dashboard view filtering for Students, Teachers, and HODs.
 - **Security Protocols**: Password hashing via BcryptJS, secure API middlewares, and cors configuration.
+- **Password Policy**: Minimum 8 characters, at least one uppercase letter, one lowercase letter, one number, and one special character.
 
 ### 👨‍🎓 Student Module
 

--- a/collegems-server/src/middlewares/validation.middleware.js
+++ b/collegems-server/src/middlewares/validation.middleware.js
@@ -1,28 +1,51 @@
 import { body, validationResult } from "express-validator";
 
+const passwordPolicyMessage =
+  "Password must be at least 8 characters long and include an uppercase letter, lowercase letter, number, and special character.";
+
 export const validateRegister = [
   body("email")
     .isEmail()
     .withMessage("Invalid email address")
     .normalizeEmail(),
+
   body("password")
-    .isLength({ min: 8 })
-    .withMessage("Password must be at least 8 characters long")
-    .matches(/^(?=.*[A-Z])(?=.*[0-9])/)
-    .withMessage("Password must contain at least one uppercase letter and one number"),
+    .isStrongPassword({
+      minLength: 8,
+      minLowercase: 1,
+      minUppercase: 1,
+      minNumbers: 1,
+      minSymbols: 1,
+      returnScore: false,
+    })
+    .withMessage(passwordPolicyMessage),
+
   body("name")
     .trim()
     .isLength({ min: 2, max: 100 })
     .withMessage("Name must be between 2 and 100 characters")
     .escape(),
+
   body("role")
     .isIn(["student", "teacher", "parent", "hod"])
     .withMessage("Role must be one of: student, teacher, parent, hod"),
+
   (req, res, next) => {
     const errors = validationResult(req);
+
     if (!errors.isEmpty()) {
-      return res.status(400).json({ errors: errors.array() });
+      const passwordError = errors.array().find(
+        (error) => error.path === "password"
+      );
+
+      return res.status(400).json({
+        message: passwordError
+          ? passwordPolicyMessage
+          : errors.array()[0].msg,
+        errors: errors.array(),
+      });
     }
+
     next();
   },
 ];

--- a/collegems-server/src/tests/auth.test.js
+++ b/collegems-server/src/tests/auth.test.js
@@ -1,0 +1,92 @@
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateRegister } from "../middlewares/validation.middleware.js";
+
+const runValidation = async (body) => {
+  const req = { body };
+
+  const res = {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+  };
+
+  let nextCalled = false;
+
+  const next = () => {
+    nextCalled = true;
+  };
+
+  for (const middleware of validateRegister) {
+    await middleware(req, res, next);
+
+    if (res.statusCode === 400) {
+      break;
+    }
+  }
+
+  return { res, nextCalled };
+};
+
+test("register validation accepts a strong password", async () => {
+  const { res, nextCalled } = await runValidation({
+    name: "Alice",
+    email: "alice@example.com",
+    password: "Password@123",
+    role: "student",
+  });
+
+  assert.equal(res.statusCode, undefined);
+  assert.equal(nextCalled, true);
+});
+
+test("register validation rejects passwords that do not meet the password policy", async (t) => {
+  const weakPasswords = [
+    "password",      // no uppercase, number, special character
+    "PASSWORD123",   // no lowercase, special character
+    "Pass123",       // too short
+    "12345678",      // only numbers
+    "Password123",   // no special character
+    "Password@",     // no number
+  ];
+
+  for (const password of weakPasswords) {
+    await t.test(`rejects "${password}"`, async () => {
+      const { res, nextCalled } = await runValidation({
+        name: "Alice",
+        email: "alice@example.com",
+        password,
+        role: "student",
+      });
+
+      assert.equal(res.statusCode, 400);
+      assert.equal(nextCalled, false);
+
+      assert.match(
+        res.payload.message,
+        /Password/i
+      );
+    });
+  }
+});
+
+test("register validation rejects missing password", async () => {
+  const { res, nextCalled } = await runValidation({
+    name: "Alice",
+    email: "alice@example.com",
+    role: "student",
+  });
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(nextCalled, false);
+});
+
+


### PR DESCRIPTION
## Description

Closes #494 

This PR strengthens the registration flow by enforcing a strong password policy using the existing validation middleware.

### Changes Made
- Added strong password validation using `express-validator`'s `isStrongPassword()`.
- Enforced the following password requirements:
  - Minimum 8 characters
  - At least one uppercase letter
  - At least one lowercase letter
  - At least one number
  - At least one special character
- Added a clear validation message for invalid passwords.
- Added unit tests covering both valid and invalid password scenarios.


## Type of Change


   New feature
   Documentation update


## Checklist

   Code follows project style
   Tested locally
   Updated documentation
