### PR TITLE
Implement announcement read tracking

### DIFF
--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -54,6 +54,7 @@ import ToastTest from "./pages/ToastTest";
 import withRoleGuard from "./hocs/withRoleGuard";
 import { UserRole } from "./constants/role.constants";
 import AccessDenied from "./pages/AccessDenied";
+import RoleRoute from "./routes/RoleRoute";
 
 // Define Guarded Components
 const StudentDashboardGuarded = withRoleGuard(StudentDashboard, { allowedRoles: UserRole.STUDENT });
@@ -199,7 +200,7 @@ export default function App() {
     
         <Route
           path="/hod/bulk-reset"
-          element={<BulkFieldResetGuarded />}
+          element={<BulkFieldResetGuarded />} 
         />
      
 

--- a/collegems-client/src/common-components-management/AnnouncementManage.tsx
+++ b/collegems-client/src/common-components-management/AnnouncementManage.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   Edit,
   X,
+  Eye,
 } from "lucide-react";
 import api from "../api/axios";
 import AnnouncementForm from "./AnnouncementForm";
@@ -62,8 +63,10 @@ export default function AnnouncementManage({ refreshKey }: AnnouncementManagePro
   const hasActiveFilters = Boolean(filterRole || filterCourse || filterSemester || filterStatus);
   const showPublishCta = !hasActiveFilters;
 
-  // inline confirm modal state
+// inline confirm modal state
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const [readCounts, setReadCounts] = useState<Record<string, number>>({});
 
   const fetchAnnouncements = async () => {
     setLoading(true);
@@ -77,8 +80,24 @@ export default function AnnouncementManage({ refreshKey }: AnnouncementManagePro
       if (filterStatus) params.status = filterStatus;
 
       const res = await api.get("/announcements", { params });
+      const list: Announcement[] = res.data.data || [];
 
-      setAnnouncements(res.data.data || []);
+      setAnnouncements(list);
+
+      const published = list.filter((a) => a.status !== "draft");
+      const results = await Promise.allSettled(
+        published.map((a) => api.get(`/announcements/${a._id}/read-stats`))
+      );
+
+      setReadCounts((prev) => {
+        const next = { ...prev };
+        results.forEach((result, i) => {
+          if (result.status === "fulfilled") {
+            next[published[i]._id] = result.value.data?.data?.totalReaders ?? 0;
+          }
+        });
+        return next;
+      });
     } catch (err) {
       console.error("Failed to fetch announcements:", err);
     } finally {
@@ -310,6 +329,15 @@ export default function AnnouncementManage({ refreshKey }: AnnouncementManagePro
                     {a.expiresAt &&
                       ` · Expires ${formatDate(a.expiresAt)}`}
                   </p>
+
+                  {/* Read tracking */}
+                  {a.status !== "draft" && (
+                    <p className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 mt-1">
+                      <Eye className="w-3.5 h-3.5" />
+                      {readCounts[a._id] ?? 0} reader
+                      {(readCounts[a._id] ?? 0) === 1 ? "" : "s"}
+                    </p>
+                  )}
                 </div>
 
                 {/* Action Buttons */}

--- a/collegems-client/src/user-components/AnnouncementsView.tsx
+++ b/collegems-client/src/user-components/AnnouncementsView.tsx
@@ -1,8 +1,7 @@
 // FILE: collegems-client/src/user-components/AnnouncementsView.tsx
-// Students (and parents) use this to read announcements meant for them.
 
 import { useEffect, useState } from "react";
-import { Bell, AlertCircle, Info, AlertTriangle, Zap } from "lucide-react";
+import { Bell, AlertCircle, Info, AlertTriangle, Zap, CheckCheck } from "lucide-react";
 import api from "../api/axios";
 
 interface Announcement {
@@ -16,6 +15,7 @@ interface Announcement {
   expiresAt: string | null;
   createdAt: string;
   postedBy: { name: string; role: string };
+  isRead?: boolean;
 }
 
 const PRIORITY_CONFIG: Record<
@@ -77,6 +77,26 @@ export default function AnnouncementsView() {
     fetch();
   }, []);
 
+// Mark an announcement as read 
+  const handleOpen = (id: string) => {
+    setExpanded((prev) => (prev === id ? null : id));
+
+    const target = announcements.find((a) => a._id === id);
+    if (!target || target.isRead) return;
+
+    setAnnouncements((prev) =>
+      prev.map((a) => (a._id === id ? { ...a, isRead: true } : a))
+    );
+
+    api.post(`/announcements/${id}/read`).catch((err) => {
+      console.error("Failed to mark announcement as read:", err);
+      
+      setAnnouncements((prev) =>
+        prev.map((a) => (a._id === id ? { ...a, isRead: false } : a))
+      );
+    });
+  };
+
   if (loading) {
     return (
       <div className="flex justify-center py-16">
@@ -130,7 +150,7 @@ export default function AnnouncementsView() {
           return (
             <button
               key={a._id}
-              onClick={() => setExpanded(isOpen ? null : a._id)}
+              onClick={() => handleOpen(a._id)}
               className={`w-full text-left bg-white dark:bg-gray-800 rounded-2xl border-2 ${cfg.card} p-4 hover:shadow-md transition-all`}
             >
               <div className="flex items-start gap-3">
@@ -152,6 +172,16 @@ export default function AnnouncementsView() {
                     {a.targetSemester && (
                       <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-50 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300">
                         Sem {a.targetSemester}
+                      </span>
+                    )}
+                    {a.isRead ? (
+                      <span className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-emerald-50 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300">
+                        <CheckCheck className="w-3 h-3" />
+                        Read
+                      </span>
+                    ) : (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-300">
+                        Unread
                       </span>
                     )}
                   </div>

--- a/collegems-server/src/controllers/announcement.controller.js
+++ b/collegems-server/src/controllers/announcement.controller.js
@@ -1,6 +1,6 @@
 // FILE: collegems-server/src/controllers/announcement.controller.js
-
 import Announcement from "../models/Announcement.model.js";
+import AnnouncementRead from "../models/AnnouncementRead.model.js";
 import User from "../models/User.model.js";
 import { sendNotification } from "../utils/notification.util.js";
 
@@ -110,12 +110,24 @@ export const getMyAnnouncements = async (req, res) => {
 
     const announcements = await Announcement.find(filter)
       .populate("postedBy", "name role")
-      .sort({ priority: -1, createdAt: -1 }); // urgent first, then newest
+      .sort({ priority: -1, createdAt: -1 });
+
+    const readRecords = await AnnouncementRead.find({
+      user: req.user.id,
+      announcement: { $in: announcements.map((a) => a._id) },
+    }).select("announcement");
+
+    const readSet = new Set(readRecords.map((r) => r.announcement.toString()));
+
+    const withReadStatus = announcements.map((a) => ({
+      ...a.toObject(),
+      isRead: readSet.has(a._id.toString()),
+    }));
 
     res.status(200).json({
       success: true,
       count: announcements.length,
-      data: announcements,
+      data: withReadStatus,
     });
   } catch (error) {
     res.status(500).json({ success: false, message: error.message });
@@ -178,6 +190,88 @@ export const getAnnouncementById = async (req, res) => {
     }
 
     res.status(200).json({ success: true, data: announcement });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+//  MARK AS READ
+export const markAnnouncementRead = async (req, res) => {
+  try {
+    const announcement = await Announcement.findById(req.params.id);
+
+    if (!announcement) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Announcement not found" });
+    }
+
+    const result = await AnnouncementRead.findOneAndUpdate(
+      { announcement: announcement._id, user: req.user.id },
+      { $setOnInsert: { announcement: announcement._id, user: req.user.id, readAt: new Date() } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+
+    res.status(200).json({
+      success: true,
+      message: "Marked as read",
+      data: { announcementId: announcement._id, readAt: result.readAt },
+    });
+  } catch (error) {
+
+    if (error.code === 11000) {
+      return res.status(200).json({ success: true, message: "Marked as read" });
+    }
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const getAnnouncementReadStats = async (req, res) => {
+  try {
+    const announcement = await Announcement.findById(req.params.id);
+
+    if (!announcement) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Announcement not found" });
+    }
+
+    // Teachers may only view stats for their own announcements.
+    if (
+      req.user.role === "teacher" &&
+      announcement.postedBy.toString() !== req.user.id
+    ) {
+      return res
+        .status(403)
+        .json({ success: false, message: "Access denied" });
+    }
+
+    const totalReaders = await AnnouncementRead.countDocuments({
+      announcement: announcement._id,
+    });
+
+    const ownRead = await AnnouncementRead.findOne({
+      announcement: announcement._id,
+      user: req.user.id,
+    });
+
+    const readers = await AnnouncementRead.find({ announcement: announcement._id })
+      .populate("user", "name email role")
+      .sort({ readAt: -1 });
+
+    res.status(200).json({
+      success: true,
+      data: {
+        announcementId: announcement._id,
+        totalReaders,
+        isReadByMe: Boolean(ownRead),
+        readAt: ownRead?.readAt || null,
+        readers: readers.map((r) => ({
+          user: r.user,
+          readAt: r.readAt,
+        })),
+      },
+    });
   } catch (error) {
     res.status(500).json({ success: false, message: error.message });
   }
@@ -285,7 +379,8 @@ export const deleteAnnouncement = async (req, res) => {
     }
 
     await announcement.deleteOne();
-
+    
+    await AnnouncementRead.deleteMany({ announcement: announcement._id });
     res.status(200).json({
       success: true,
       message: "Announcement deleted successfully",

--- a/collegems-server/src/models/AnnouncementRead.model.js
+++ b/collegems-server/src/models/AnnouncementRead.model.js
@@ -1,0 +1,35 @@
+// FILE: collegems-server/src/models/AnnouncementRead.model.js
+import mongoose from "mongoose";
+
+const AnnouncementReadSchema = new mongoose.Schema(
+  {
+    announcement: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Announcement",
+      required: true,
+    },
+
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+
+    readAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { timestamps: true }
+);
+
+AnnouncementReadSchema.index({ announcement: 1, user: 1 }, { unique: true });
+
+AnnouncementReadSchema.index({ announcement: 1 });
+
+const AnnouncementRead = mongoose.model(
+  "AnnouncementRead",
+  AnnouncementReadSchema
+);
+
+export default AnnouncementRead;

--- a/collegems-server/src/routes/announcement.routes.js
+++ b/collegems-server/src/routes/announcement.routes.js
@@ -8,6 +8,8 @@ import {
   getAnnouncementById,
   updateAnnouncement,
   deleteAnnouncement,
+  markAnnouncementRead,
+  getAnnouncementReadStats,
 } from "../controllers/announcement.controller.js";
 import { protect } from "../middlewares/auth.middleware.js";
 import { allowRoles } from "../middlewares/role.middleware.js";
@@ -28,6 +30,9 @@ router.get(
 );
 
 router.get("/:id", getAnnouncementById);
+
+router.post("/:id/read", markAnnouncementRead);
+router.get("/:id/read-stats", allowRoles("hod", "teacher"), getAnnouncementReadStats);
 
 router.post(
   "/",


### PR DESCRIPTION
# Description

This PR implements **Announcement Read Tracking** for the Targeted Announcement System (Issue No.: #300 ).

### Chnages: 

* Added an `AnnouncementRead` model to record which users have read an announcement and when it was opened.
* Implemented logic to mark an announcement as read when a student or parent opens it.
* Ensured each announcement is recorded as read only once per user, preventing duplicate read entries.
* Added a **Read/Unread** status badge for students and parents in the announcements view.
* Added a **Total Readers** count for teachers and HODs to track engagement with announcements.

### Criteria

* Reads are recorded only once per user per announcement.
* Read/Unread status is visible to students and parents.
* Reader count is visible to teachers and HODs.

### Files Changed

#### Backend

* `announcement.controller.js`

  * Added logic to record announcement reads.
  * Added functionality to retrieve read statistics.
* `announcement.routes.js`

  * Added endpoints for recording reads and fetching read statistics.

#### Frontend

* `AnnouncementsView.tsx`

  * Displays Read/Unread status for students and parents.
* `AnnouncementManage.tsx`

  * Displays total reader count for teachers and HODs.

### New File

* `AnnouncementRead.model.js`

##Screenshots
<img width="1920" height="1080" alt="Screenshot (287)" src="https://github.com/user-attachments/assets/81fa412a-c879-413c-8a6a-19d6f20be32d" />
<img width="1917" height="972" alt="Screenshot 2026-06-27 225352" src="https://github.com/user-attachments/assets/dc65303f-2203-45e2-9677-7d1213c0e11e" />



Closes: #300 

