### PR TITLE
fix(a11y): add htmlFor/id label associations to ResetPassword form controls (WCAG 2.2 SC 1.3.1)

### DIFF
--- a/collegems-client/src/pages/auth/ResetPassword.tsx
+++ b/collegems-client/src/pages/auth/ResetPassword.tsx
@@ -117,7 +117,7 @@ export default function ResetPassword() {
         <div className="bg-white dark:bg-gray-800 py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-gray-200 dark:border-gray-700">
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label htmlFor="reset-new-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                 New Password
               </label>
               <div className="mt-1 relative rounded-md shadow-sm">
@@ -125,6 +125,7 @@ export default function ResetPassword() {
                   <Lock className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
+                  id="reset-new-password"
                   type={showPassword ? "text" : "password"}
                   required
                   value={password}
@@ -156,7 +157,7 @@ export default function ResetPassword() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label htmlFor="reset-confirm-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                 Confirm Password
               </label>
               <div className="mt-1 relative rounded-md shadow-sm">
@@ -164,6 +165,7 @@ export default function ResetPassword() {
                   <Lock className="h-5 w-5 text-gray-400" />
                 </div>
                 <input
+                  id="reset-confirm-password"
                   type={showPassword ? "text" : "password"}
                   required
                   value={confirmPassword}


### PR DESCRIPTION
## Problem

Following the fixes in previous PRs for Student, Teacher, and HOD components,
the same WCAG 2.2 Level A violation (SC 1.3.1 — Info and Relationships)
exists in the newly added `ResetPassword` auth component.

`<label>` elements have no `htmlFor` and their controls have no `id`,
so screen readers cannot announce field names on focus.

## Files Affected

`collegems-client/src/pages/auth/ResetPassword.tsx`
- New Password field — label missing `htmlFor`, input missing `id`
- Confirm Password field — label missing `htmlFor`, input missing `id`

## Changes Made

| Field | htmlFor / id added |
|---|---|
| New Password | `reset-new-password` |
| Confirm Password | `reset-confirm-password` |

## Type of Change
- [x] Bug fix (accessibility)

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation

Closes #523
