### PR TITLE
fix(search): prevent regex injection and ReDoS in global search endpoint

### DIFF
--- a/collegems-server/src/controllers/search.controller.js
+++ b/collegems-server/src/controllers/search.controller.js
@@ -3,6 +3,13 @@ import Course from "../models/Course.model.js";
 import Announcement from "../models/Announcement.model.js";
 import Assignment from "../models/Assignment.model.js";
 
+// Escape user input so it is treated as a literal string in a RegExp,
+// preventing regex injection and ReDoS via crafted patterns.
+const escapeRegExp = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Cap query length to avoid pathological/expensive searches.
+const MAX_QUERY_LENGTH = 100;
+
 const getMatchReason = (doc, query, fields) => {
   const q = query.toLowerCase();
   for (const field of fields) {
@@ -22,8 +29,14 @@ const getMatchReason = (doc, query, fields) => {
 export const globalSearch = async (req, res) => {
   try {
     const { q } = req.query;
-    if (!q) {
+    if (!q || typeof q !== "string" || !q.trim()) {
       return res.status(400).json({ success: false, message: "Search query is required" });
+    }
+    if (q.length > MAX_QUERY_LENGTH) {
+      return res.status(400).json({
+        success: false,
+        message: `Search query must be at most ${MAX_QUERY_LENGTH} characters`,
+      });
     }
 
     const user = req.user; // from auth middleware
@@ -32,8 +45,9 @@ export const globalSearch = async (req, res) => {
     // We limit results for performance
     const LIMIT = 5;
 
-    // Build base regex for case-insensitive search
-    const regex = new RegExp(q, 'i');
+    // Build base regex for case-insensitive search.
+    // Escape the input so it is matched literally (no regex injection / ReDoS).
+    const regex = new RegExp(escapeRegExp(q), 'i');
 
     // 1. Search Users (Students/Faculty)
     // RBAC: Students can only search faculty/teachers. Teachers/Admins can search anyone.


### PR DESCRIPTION
## Summary

Fixes #504

The global search endpoint (`src/controllers/search.controller.js`) built a regular expression directly from unsanitized user input:

```js
const regex = new RegExp(q, 'i');
```

This allowed **regex injection** (attackers could inject metacharacters to alter query semantics) and **ReDoS** — a crafted input such as `(a+)+$` triggers catastrophic backtracking, blocking the Node.js event loop and taking the server down with a single request.

## Changes

- Added an `escapeRegExp` helper so user input is matched **literally** instead of being interpreted as a pattern.
- Capped query length at 100 characters (`MAX_QUERY_LENGTH`) to avoid pathological/expensive searches.
- Hardened input validation to ensure `q` is a non-empty string.

## Verification

- Malicious pattern `(a+)+$` is now matched as a literal string — no catastrophic backtracking.
- Normal substring search (e.g. `john` matching `Johnny`) continues to work.
- `node --check` passes on the modified file.