### PR TITLE
ci: add PR pipeline running server tests and client lint (closes #505)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+# Cancel superseded runs for the same PR/branch when new commits are pushed.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  server-tests:
+    name: Server tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: collegems-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: collegems-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Tests run on every PR via the in-process mongodb-memory-server (no
+      # external DB needed). Marked advisory for now because master currently
+      # carries a backlog of pre-existing failing tests; results are surfaced
+      # so regressions are visible. Remove `continue-on-error` to make this a
+      # hard merge gate once the existing failures are fixed.
+      - name: Run tests
+        run: npm test
+        continue-on-error: true
+        env:
+          NODE_ENV: test
+
+  client-lint:
+    name: Client lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: collegems-client
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: collegems-client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Advisory for now: the client carries a backlog of pre-existing ESLint
+      # errors. Results are surfaced on every PR; remove `continue-on-error` to
+      # make lint a hard merge gate once the existing violations are fixed.
+      - name: Run ESLint
+        run: npm run lint
+        continue-on-error: true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` — the repository's first CI pipeline that runs on every pull request (and on pushes to `master`).

Previously all workflows under `.github/workflows/` were GitHub automation only (auto-assign, labeling, stale, etc.) — **none** ran `npm test` or `npm run lint`. As a result, broken tests and lint violations could merge undetected.

Closes #505.

## What the workflow does

Two parallel jobs, each pinned to Node 24 with npm dependency caching:

- **`server-tests`** — `cd collegems-server && npm ci && npm test`
  - The server suite (`node --test src/tests/*.test.js`) uses an in-process `mongodb-memory-server`, so no external MongoDB service is required.
- **`client-lint`** — `cd collegems-client && npm ci && npm run lint`

Also includes `concurrency` (cancels superseded runs per branch) and per-job `timeout-minutes` guards.

## Advisory rollout (important)

Both steps currently use `continue-on-error: true`, so they **run and report on every PR but do not yet hard-block merges**. This is deliberate because `master` already carries a pre-existing backlog:

- **Client lint:** ~404 ESLint errors on the existing codebase.
- **Server tests:** several pre-existing failing tests (e.g. `abandonmentTracking` uses role `"admin"`, which isn't in the `User` model enum; `upcomingExams` has failing assertions), plus at least one slow/hanging test file.

Hard-blocking from day one would fail every PR. Making CI advisory first surfaces these issues on every PR without blocking unrelated work. Once the backlog is cleared, removing the `continue-on-error` flags turns each step into a hard merge gate.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- `collegems-client`: `npm ci` + `npm run lint` run (surfaces the pre-existing lint backlog).
- `collegems-server`: `npm ci` + `npm test` run; passing files (e.g. `pagination`, `cache`, `alumniNetwork`) confirmed green, pre-existing failures identified.