### PR TITLE
fix(library): stop getIssueRecords from mutating data on read (closes #507)

### DIFF
--- a/collegems-server/src/controllers/library.controller.js
+++ b/collegems-server/src/controllers/library.controller.js
@@ -223,23 +223,24 @@ export const getIssueRecords = async (req, res) => {
       }
     }
 
-    // Update overdue statuses dynamically
-    const activeIssues = await BookIssue.find({
-      status: "issued",
-      dueDate: { $lt: new Date() },
-    });
-
-    for (let issue of activeIssues) {
-      issue.status = "overdue";
-      await issue.save();
-    }
-
+    // GET must be side-effect free, so we do not persist status changes here.
+    // The "issued" -> "overdue" transition (and its fines/notifications) is
+    // owned by the daily processLibraryFines cron job. We only derive the
+    // overdue status at read time so the response stays accurate between runs.
+    const now = new Date();
     const issues = await BookIssue.find(query)
       .populate("book", "title author category")
       .populate("user", "name email role studentId teacherId")
-      .sort({ createdAt: -1 });
+      .sort({ createdAt: -1 })
+      .lean();
 
-    res.json({ success: true, issues });
+    const issuesWithDerivedStatus = issues.map((issue) =>
+      issue.status === "issued" && issue.dueDate < now
+        ? { ...issue, status: "overdue" }
+        : issue
+    );
+
+    res.json({ success: true, issues: issuesWithDerivedStatus });
   } catch (error) {
     res.status(500).json({ success: false, message: error.message });
   }

--- a/collegems-server/src/tests/getIssueRecordsReadOnly.test.js
+++ b/collegems-server/src/tests/getIssueRecordsReadOnly.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import request from "supertest";
+import app from "../app.js";
+import User from "../models/User.model.js";
+import Book from "../models/Book.model.js";
+import BookIssue from "../models/BookIssue.model.js";
+import jwt from "jsonwebtoken";
+
+// Regression test for #507: GET /api/library/issues must not mutate data.
+// It previously flipped overdue "issued" records to "overdue" and saved them
+// on read. The response should still reflect overdue status (derived), but the
+// persisted record must remain untouched by the GET handler.
+test("getIssueRecords does not persist overdue status on read", async (t) => {
+  let mongoServer;
+  let student;
+  let studentToken;
+  let overdueIssue;
+
+  t.before(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+
+    const jwtSecret = process.env.JWT_SECRET || "testsecret";
+    process.env.JWT_SECRET = jwtSecret;
+
+    student = await User.create({
+      name: "Read-Only Student",
+      email: "readonly.student@test.com",
+      password: "password123",
+      role: "student",
+      studentId: "S-RO-507",
+      semester: "3",
+      course: "Computer Science",
+    });
+
+    studentToken = jwt.sign({ id: student._id, role: student.role }, jwtSecret);
+
+    const book = await Book.create({
+      title: "Overdue Book",
+      author: "Jane Doe",
+      category: "Fiction",
+      isbn: "978-0000000507",
+      quantity: 5,
+      availableQuantity: 4,
+    });
+
+    const threeDaysAgo = new Date();
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
+    // Past due but still stored as "issued" (the cron job hasn't run yet).
+    overdueIssue = await BookIssue.create({
+      book: book._id,
+      user: student._id,
+      issueDate: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+      dueDate: threeDaysAgo,
+      status: "issued",
+    });
+  });
+
+  t.after(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  await t.test("response derives overdue status", async () => {
+    const res = await request(app)
+      .get("/api/library/issues")
+      .set("Authorization", `Bearer ${studentToken}`);
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.body.success, true);
+
+    const returned = res.body.issues.find(
+      (i) => String(i._id) === String(overdueIssue._id)
+    );
+    assert.ok(returned, "issued record should be returned");
+    assert.strictEqual(
+      returned.status,
+      "overdue",
+      "past-due record should read as overdue"
+    );
+  });
+
+  await t.test("stored record is not mutated by the GET", async () => {
+    const stored = await BookIssue.findById(overdueIssue._id);
+    assert.strictEqual(
+      stored.status,
+      "issued",
+      "GET must not persist the overdue transition"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`getIssueRecords` (`GET /api/library/issues`) is a read handler that was **writing to the database**: on every request it queried `issued` books past their `dueDate` and saved them as `overdue`. GET requests should be safe/idempotent — mutating data on read caused surprising side effects, race conditions under concurrent reads, and extra DB load.

Closes #507.

## Root cause

`src/controllers/library.controller.js` ran this on every read:

```js
const activeIssues = await BookIssue.find({ status: "issued", dueDate: { $lt: new Date() } });
for (let issue of activeIssues) {
  issue.status = "overdue";
  await issue.save();
}
```

This is also **redundant and incomplete**: the daily `processLibraryFines` cron job (`src/utils/cronJobs.js`, started via `startLibraryCronJobs`) already owns the `issued -> overdue` transition *and* creates the associated fines + notifications. The read path only flipped the status, skipping the fine/notification logic.

## Fix

Remove the write from the read path and instead **derive** the overdue status at read time (without persisting), so the API response stays accurate between cron runs:

```js
const now = new Date();
const issues = await BookIssue.find(query)
  .populate(...)
  .sort({ createdAt: -1 })
  .lean();

const issuesWithDerivedStatus = issues.map((issue) =>
  issue.status === "issued" && issue.dueDate < now
    ? { ...issue, status: "overdue" }
    : issue
);
```

The actual persistence (and fines/notifications) remains owned by the cron job. `.lean()` is safe here — `BookIssue` has no virtuals or `toJSON` transforms.

## Testing

Added `src/tests/getIssueRecordsReadOnly.test.js`, which seeds a past-due record stored as `issued`, calls `GET /api/library/issues`, and asserts:

- the response reflects `overdue` (derived), and
- the stored record remains `issued` (the GET does not persist the transition).

Both assertions pass locally:

```
✔ response derives overdue status
✔ stored record is not mutated by the GET
```