### PR TITLE
fix: revoke object URL for LostFoundPortal file preview

### DIFF
--- a/collegems-client/src/pages/LostFoundPortal.tsx
+++ b/collegems-client/src/pages/LostFoundPortal.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 const LostFoundPortal = () => {
   const [activeTab, setActiveTab] = useState("lost");
@@ -8,6 +8,11 @@ const LostFoundPortal = () => {
   const [showClaimModal, setShowClaimModal] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
   const [preview, setPreview] = useState("");
+
+  useEffect(() => {
+    if (!preview) return;
+    return () => URL.revokeObjectURL(preview);
+  }, [preview]);
 
   const lostItems = [
     {


### PR DESCRIPTION
## Summary
- `URL.createObjectURL(file)` in `LostFoundPortal.tsx` was never paired with a matching `URL.revokeObjectURL`, leaking the underlying blob each time a user selected/changed a file before submitting the report form.
- Added a `useEffect` that revokes the previous preview URL whenever `preview` changes and on unmount, per the fix suggested in the issue.

Fixes #514

## Test plan
- [x] Ran the app locally, opened the "Report New Item" modal, selected a file, confirmed the preview renders from a `blob:` URL.
- [x] Selected a second file and confirmed the first blob URL is revoked (via instrumented `URL.revokeObjectURL`) at the moment the new preview is created.
- [x] Navigated away from the page with a preview set and confirmed the outstanding blob URL is revoked on unmount.
- [x] `eslint` passes on the changed file with no new warnings.