### PR TITLE
fix: restrict permissive CORS in microservices gateway & socket server

### DIFF
--- a/collegems-server/microservices.js
+++ b/collegems-server/microservices.js
@@ -10,6 +10,7 @@ import { Server } from "socket.io";
 import { connectDB } from "./src/config/db.js";
 import { connectRabbitMQ } from "./src/utils/rabbitmq.js";
 import { startPlagiarismWorker } from "./src/workers/plagiarismWorker.js";
+import { allowedOrigins } from "./src/config/cors.js";
 
 import authRoutes from "./src/routes/auth.routes.js";
 import userRoutes from "./src/routes/user.routes.js";
@@ -31,7 +32,16 @@ const startService = async () => {
   const app = express();
   
   // CORS & Body parsing
-  app.use(cors({ origin: true, credentials: true }));
+  app.use(cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    credentials: true,
+  }));
   
   if (SERVICE_NAME !== "gateway") {
     app.use(express.json());
@@ -94,7 +104,16 @@ const startService = async () => {
   if (SERVICE_NAME === "academics" || SERVICE_NAME === "gateway") {
     // Academics needs websockets for study groups and chat
     const io = new Server(httpServer, {
-      cors: { origin: true, credentials: true }
+      cors: {
+        origin: (origin, callback) => {
+          if (!origin || allowedOrigins.includes(origin)) {
+            callback(null, true);
+          } else {
+            callback(new Error("Not allowed by CORS"));
+          }
+        },
+        credentials: true,
+      }
     });
     app.set("io", io);
     if (SERVICE_NAME === "academics") {


### PR DESCRIPTION
## Summary
- `microservices.js` configured both the Express CORS middleware and the Socket.IO server with `origin: true, credentials: true`, which reflects *any* request origin back and combines it with credentials — effectively disabling the same-origin protection CORS is meant to provide, and enabling CSRF-style/cross-origin data-theft attacks against authenticated users.
- Replaced `origin: true` with the same explicit allowlist (`allowedOrigins` from `src/config/cors.js`) the main server (`src/app.js`) already uses, applied consistently to both the gateway's Express CORS middleware and its Socket.IO server.

Fixes #512

## Test plan
- [x] Started the gateway service locally (`SERVICE_NAME=gateway`) and sent a CORS preflight request with `Origin: http://localhost:5173` (the default allowlisted origin) — response includes `Access-Control-Allow-Origin: http://localhost:5173`.
- [x] Sent the same preflight with `Origin: http://evil.example.com` — response has no `Access-Control-Allow-Origin` header, so a browser would block it.
- [x] Connected a real Socket.IO client to the gateway with `Origin: http://localhost:5173` — connection succeeds.
- [x] Connected the same client with `Origin: http://evil.example.com` — connection is rejected (`connect_error`).