### PR TITLE
docs: add missing collegems-server/.env.example

### DIFF
--- a/collegems-server/.env.example
+++ b/collegems-server/.env.example
@@ -1,0 +1,57 @@
+# Core server settings
+PORT=5000
+NODE_ENV=development
+
+# MongoDB connection string. Ignored when USE_MEMORY_DB=true.
+MONGO_URI=mongodb://localhost:27017/collegems
+
+# Set to "true" to spin up an in-memory MongoDB instance instead of
+# connecting to MONGO_URI (handy for local dev without a real database).
+USE_MEMORY_DB=false
+
+# Secrets used to sign/verify JWTs. Use long, random values.
+JWT_SECRET=your_super_secure_jwt_secret
+JWT_REFRESH_SECRET=your_super_secure_jwt_refresh_secret
+
+# Comma-separated list of origins allowed to make CORS requests
+# (also used for the Socket.IO CORS allowlist).
+ALLOWED_ORIGINS=http://localhost:5173
+
+# Base URL of the client app, used to build links in emails
+# (verification, password reset, etc.).
+FRONTEND_URL=http://localhost:5173
+
+# URL of the client app's backend API base, used as a fallback when
+# building links to files/downloads server-side.
+VITE_BACKEND_URL=http://localhost:5000/api
+
+# Base URL used when generating public ID-card verification links.
+VERIFY_BASE_URL=http://localhost:5000
+
+# Outgoing email (nodemailer) settings, e.g. for verification and
+# password-reset emails.
+EMAIL_SERVICE=gmail
+EMAIL_USER=your-email@gmail.com
+EMAIL_PASS=your-app-password
+
+# Branding shown on generated ID cards.
+COLLEGE_NAME=Smart College of Engineering
+COLLEGE_TAGLINE=Smart College Management System
+COLLEGE_DOMAIN=college.edu
+
+# URL of the Python ML microservice used for analytics/predictions.
+ML_SERVICE_URL=http://localhost:8000
+
+# RabbitMQ connection string for the microservices event bus.
+RABBITMQ_URL=amqp://localhost:5672
+# Set to "true" to mock RabbitMQ with an in-process event emitter
+# instead of connecting to a real broker (handy for local dev).
+MOCK_RABBITMQ=false
+
+# Which microservice this process runs as when started via
+# microservices.js (gateway | auth | finance | notification | academics).
+SERVICE_NAME=gateway
+
+# Attendance anomaly-detection thresholds.
+CONSECUTIVE_ABSENCE_THRESHOLD=3
+MISSING_ATTENDANCE_DAYS_THRESHOLD=5


### PR DESCRIPTION
## Summary
- README's setup steps tell contributors to run \`cp .env.example .env\` for the backend, but \`collegems-server/.env.example\` didn't exist — new contributors had no way to tell which environment variables were required and had to guess names and fail at runtime.
- Added \`collegems-server/.env.example\` listing every variable the server reads via \`process.env\` (found by grepping the whole codebase), each with a placeholder value and a short comment explaining its purpose.

Fixes #508

## Test plan
- [x] Cross-checked the variable names in the new \`.env.example\` against every \`process.env.*\` reference in \`collegems-server\` (excluding \`node_modules\`) — exact match both ways, nothing missing and nothing extra.
- [x] Ran \`cp .env.example .env\` per the README's own instructions and booted the server against the resulting file (via \`node --env-file\`) — server starts successfully and the JWT-secret startup check passes, confirming the file's variable names and format are actually usable, not just plausible-looking.