### PR TITLE
fix: add catch-all 404 route for unmatched URLs

### DIFF
--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -54,6 +54,7 @@ import ToastTest from "./pages/ToastTest";
 import withRoleGuard from "./hocs/withRoleGuard";
 import { UserRole } from "./constants/role.constants";
 import AccessDenied from "./pages/AccessDenied";
+import NotFound from "./pages/NotFound";
 import RoleRoute from "./routes/RoleRoute";
 
 // Define Guarded Components
@@ -208,6 +209,8 @@ export default function App() {
           path="/parent/dashboard"
           element={<ParentDashboardGuarded />}
         />
+
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
   );

--- a/collegems-client/src/pages/NotFound.tsx
+++ b/collegems-client/src/pages/NotFound.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+const NotFound: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
+      <div className="bg-white rounded-lg shadow-lg p-8 max-w-md text-center border-t-4 border-blue-500">
+        <div className="flex justify-center mb-4">
+          <svg
+            className="w-16 h-16 text-blue-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            ></path>
+          </svg>
+        </div>
+        <h1 className="text-2xl font-bold text-gray-800 mb-2">404 - Page Not Found</h1>
+        <p className="text-gray-600 mb-6">
+          The page you're looking for doesn't exist or may have been moved.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={() => navigate(-1)}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 transition-colors"
+          >
+            Go Back
+          </button>
+          <Link
+            to="/"
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+          >
+            Return to Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- The \`<Routes>\` block in \`App.tsx\` had no \`path="*"\` catch-all, so navigating to any URL that didn't match a defined route rendered a completely blank white page, with no "Not Found" message, no error, and no way back to a valid page.
- Added a \`NotFound\` page (styled to match the existing \`AccessDenied\` page for visual consistency) with "Go Back" and "Return to Dashboard" actions, and wired it up as the catch-all route. "Return to Dashboard" links to \`/\`, which already redirects to \`/login\` or the appropriate dashboard based on auth state, so this works correctly for both logged-out and logged-in users without hardcoding a specific destination.

Fixes #574

## Test plan
- [x] \`tsc --noEmit\` shows no errors for the changed/new files.
- [x] Ran the app locally and navigated to an unknown URL (\`/this-route-does-not-exist\`) in a real browser — renders the "404 - Page Not Found" page instead of a blank screen, with no console errors.
- [x] Clicked "Return to Dashboard" from the 404 page while unauthenticated — correctly redirected to \`/login\`.