### PR TITLE
fix: use req.user.id instead of req.user._id/userId (cross-user data leak)

### DIFF
--- a/collegems-server/src/controllers/clubs.controller.js
+++ b/collegems-server/src/controllers/clubs.controller.js
@@ -32,7 +32,7 @@ const populateClub = (query) =>
 export const createClub = async (req, res) => {
   try {
     const { name, description, category, logo, maxMembers } = req.body;
-    const userId = req.user._id || req.user.id; // FIXED: fallback to ensure valid ID
+    const userId = req.user.id;
 
     if (!name || !description) {
       return res.status(400).json({ message: "Name and description are required" });
@@ -93,7 +93,7 @@ export const getClubById = async (req, res) => {
 // ─── Get clubs current user belongs to (member or admin) ──────────────────────────
 export const getMyClubs = async (req, res) => {
   try {
-    const userId = req.user._id || req.user.id;
+    const userId = req.user.id;
     const clubs = await populateClub(
       Club.find({ "members.user": userId }).sort({ createdAt: -1 })
     );
@@ -108,7 +108,7 @@ export const getMyClubs = async (req, res) => {
 export const updateClub = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const userId = req.user._id || req.user.id;
+    const userId = req.user.id;
     
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -140,7 +140,7 @@ export const updateClub = async (req, res) => {
 export const deleteClub = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const userId = req.user._id || req.user.id;
+    const userId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -160,7 +160,7 @@ export const deleteClub = async (req, res) => {
 export const requestToJoin = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const userId = req.user._id || req.user.id; // FIXED: Guarantees a valid ID
+    const userId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -195,7 +195,7 @@ export const requestToJoin = async (req, res) => {
 export const getPendingRequests = async (req, res) => {
   try {
     const club = await populateClub(Club.findById(req.params.id));
-    const userId = req.user._id || req.user.id;
+    const userId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -214,7 +214,7 @@ export const getPendingRequests = async (req, res) => {
 export const approveRequest = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const adminId = req.user._id || req.user.id;
+    const adminId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -250,7 +250,7 @@ export const approveRequest = async (req, res) => {
 export const rejectRequest = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const adminId = req.user._id || req.user.id;
+    const adminId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -279,7 +279,7 @@ export const rejectRequest = async (req, res) => {
 export const removeMember = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const adminId = req.user._id || req.user.id;
+    const adminId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -312,7 +312,7 @@ export const removeMember = async (req, res) => {
 export const updateMemberRole = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const adminId = req.user._id || req.user.id;
+    const adminId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -354,7 +354,7 @@ export const updateMemberRole = async (req, res) => {
 export const linkEventToClub = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const adminId = req.user._id || req.user.id;
+    const adminId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -391,7 +391,7 @@ export const linkEventToClub = async (req, res) => {
 export const unlinkEventFromClub = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const adminId = req.user._id || req.user.id;
+    const adminId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -431,7 +431,7 @@ export const getClubEvents = async (req, res) => {
 export const addAnnouncement = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const userId = req.user._id || req.user.id;
+    const userId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 
@@ -463,7 +463,7 @@ export const addAnnouncement = async (req, res) => {
 export const deleteAnnouncement = async (req, res) => {
   try {
     const club = await Club.findById(req.params.id);
-    const userId = req.user._id || req.user.id;
+    const userId = req.user.id;
 
     if (!club) return res.status(404).json({ message: "Club not found" });
 

--- a/collegems-server/src/controllers/complaint.controller.js
+++ b/collegems-server/src/controllers/complaint.controller.js
@@ -6,7 +6,7 @@ export const createComplaint = async (req, res) => {
     const { title, description, category, priority, evidenceUrl } = req.body;
     
     const newComplaint = new Complaint({
-      student: req.user._id,
+      student: req.user.id,
       title,
       description,
       category,
@@ -24,7 +24,7 @@ export const createComplaint = async (req, res) => {
 // Get all complaints for the logged-in student
 export const getMyComplaints = async (req, res) => {
   try {
-    const complaints = await Complaint.find({ student: req.user._id })
+    const complaints = await Complaint.find({ student: req.user.id })
       .populate("assignedTo", "name email department")
       .populate("comments.sender", "name role")
       .sort({ createdAt: -1 });
@@ -69,7 +69,7 @@ export const getComplaintById = async (req, res) => {
     }
 
     // Ensure student can only view their own complaint unless they are admin
-    if (req.user.role === "student" && complaint.student._id.toString() !== req.user._id.toString()) {
+    if (req.user.role === "student" && complaint.student._id.toString() !== req.user.id.toString()) {
       return res.status(403).json({ message: "Access denied" });
     }
 
@@ -127,12 +127,12 @@ export const addComment = async (req, res) => {
     }
 
     // Ensure student can only comment on their own complaint
-    if (req.user.role === "student" && complaint.student.toString() !== req.user._id.toString()) {
+    if (req.user.role === "student" && complaint.student.toString() !== req.user.id.toString()) {
       return res.status(403).json({ message: "Access denied" });
     }
 
     complaint.comments.push({
-      sender: req.user._id,
+      sender: req.user.id,
       message,
       timestamp: new Date()
     });

--- a/collegems-server/src/controllers/history.controller.js
+++ b/collegems-server/src/controllers/history.controller.js
@@ -4,7 +4,7 @@ const HISTORY_LIMIT = 20;
 
 export const getHistory = async (req, res) => {
   try {
-    const history = await RecentHistory.find({ user: req.user._id })
+    const history = await RecentHistory.find({ user: req.user.id })
       .sort({ viewedAt: -1 })
       .limit(HISTORY_LIMIT);
     res.status(200).json({ success: true, data: history });
@@ -19,13 +19,13 @@ export const addHistoryEntry = async (req, res) => {
     
     // Upsert the entry (update viewedAt if it exists)
     await RecentHistory.findOneAndUpdate(
-      { user: req.user._id, entityType, entityId },
+      { user: req.user.id, entityType, entityId },
       { displayName, url, viewedAt: Date.now() },
       { upsert: true, new: true, setDefaultsOnInsert: true }
     );
 
     // Enforce limit: find the 20th item and delete anything older
-    const excessEntries = await RecentHistory.find({ user: req.user._id })
+    const excessEntries = await RecentHistory.find({ user: req.user.id })
       .sort({ viewedAt: -1 })
       .skip(HISTORY_LIMIT)
       .select('_id');

--- a/collegems-server/src/controllers/mentorship.controller.js
+++ b/collegems-server/src/controllers/mentorship.controller.js
@@ -38,7 +38,7 @@ export const assignMentor = async (req, res) => {
 
 export const getMyMentees = async (req, res) => {
   try {
-    const mentorships = await Mentorship.find({ mentor: req.user.userId || req.user.id, status: "active" })
+    const mentorships = await Mentorship.find({ mentor: req.user.id, status: "active" })
       .populate("mentee", "name email studentId course semester");
     res.json(mentorships);
   } catch (error) {
@@ -48,7 +48,7 @@ export const getMyMentees = async (req, res) => {
 
 export const getMyMentors = async (req, res) => {
   try {
-    const mentorships = await Mentorship.find({ mentee: req.user.userId || req.user.id, status: "active" })
+    const mentorships = await Mentorship.find({ mentee: req.user.id, status: "active" })
       .populate("mentor", "name email teacherId department");
     res.json(mentorships);
   } catch (error) {

--- a/collegems-server/src/controllers/notification.controller.js
+++ b/collegems-server/src/controllers/notification.controller.js
@@ -3,7 +3,7 @@ import Notification from "../models/Notification.model.js";
 // Get user's notifications
 export const getNotifications = async (req, res) => {
   try {
-    const notifications = await Notification.find({ recipient: req.user.id || req.user._id })
+    const notifications = await Notification.find({ recipient: req.user.id })
       .sort({ createdAt: -1 })
       .limit(50);
     res.status(200).json(notifications);
@@ -16,7 +16,7 @@ export const getNotifications = async (req, res) => {
 export const markAsRead = async (req, res) => {
   try {
     const notification = await Notification.findOneAndUpdate(
-      { _id: req.params.id, recipient: req.user.id || req.user._id },
+      { _id: req.params.id, recipient: req.user.id },
       { isRead: true },
       { new: true }
     );
@@ -33,7 +33,7 @@ export const markAsRead = async (req, res) => {
 export const markAllAsRead = async (req, res) => {
   try {
     await Notification.updateMany(
-      { recipient: req.user.id || req.user._id, isRead: false },
+      { recipient: req.user.id, isRead: false },
       { $set: { isRead: true } }
     );
     res.status(200).json({ message: "All notifications marked as read" });

--- a/collegems-server/src/controllers/ownership.controller.js
+++ b/collegems-server/src/controllers/ownership.controller.js
@@ -75,7 +75,7 @@ export const transferOwnership = async (req, res) => {
     }
 
     // Authorization: User must be admin, hod, or the current owner
-    const isOwner = record.ownerId && record.ownerId.toString() === req.user._id.toString();
+    const isOwner = record.ownerId && record.ownerId.toString() === req.user.id.toString();
     const isAdminOrHod = ["admin", "hod"].includes(req.user.role);
     
     if (!isOwner && !isAdminOrHod) {
@@ -96,7 +96,7 @@ export const transferOwnership = async (req, res) => {
     record.ownershipHistory.push({
       previousOwnerId: previousOwnerId || null,
       newOwnerId: newOwnerId,
-      transferredBy: req.user._id,
+      transferredBy: req.user.id,
       reason: reason || "Ownership transferred via dashboard",
     });
 

--- a/collegems-server/src/controllers/savedFilter.controller.js
+++ b/collegems-server/src/controllers/savedFilter.controller.js
@@ -6,7 +6,7 @@ import SavedFilter from "../models/SavedFilter.model.js";
 export const getSavedFilters = async (req, res) => {
   try {
     const filters = await SavedFilter.find({
-      user: req.user._id,
+      user: req.user.id,
       dashboard: req.params.dashboard,
     }).sort({ createdAt: -1 });
 
@@ -28,7 +28,7 @@ export const createSavedFilter = async (req, res) => {
     }
 
     // Check if the user already has a filter with this name on this dashboard
-    const existing = await SavedFilter.findOne({ user: req.user._id, dashboard, name });
+    const existing = await SavedFilter.findOne({ user: req.user.id, dashboard, name });
     
     if (existing) {
       // If it exists, update it rather than throwing an error (acts like an overwrite)
@@ -38,7 +38,7 @@ export const createSavedFilter = async (req, res) => {
     }
 
     const savedFilter = await SavedFilter.create({
-      user: req.user._id,
+      user: req.user.id,
       name,
       dashboard,
       filters,
@@ -66,7 +66,7 @@ export const deleteSavedFilter = async (req, res) => {
     }
 
     // Ensure the user owns this filter
-    if (filter.user.toString() !== req.user._id.toString()) {
+    if (filter.user.toString() !== req.user.id.toString()) {
       return res.status(403).json({ success: false, message: "Not authorized to delete this filter" });
     }
 

--- a/collegems-server/src/controllers/studyGroup.controller.js
+++ b/collegems-server/src/controllers/studyGroup.controller.js
@@ -10,8 +10,8 @@ export const createStudyGroup = async (req, res) => {
       name,
       description,
       course,
-      createdBy: req.user.userId,
-      members: [req.user.userId], // Creator is automatically a member
+      createdBy: req.user.id,
+      members: [req.user.id], // Creator is automatically a member
     });
     await studyGroup.save();
     res.status(201).json(studyGroup);
@@ -41,8 +41,8 @@ export const joinStudyGroup = async (req, res) => {
       return res.status(404).json({ message: "Study group not found" });
     }
     
-    if (!studyGroup.members.includes(req.user.userId)) {
-      studyGroup.members.push(req.user.userId);
+    if (!studyGroup.members.includes(req.user.id)) {
+      studyGroup.members.push(req.user.id);
       await studyGroup.save();
     }
     
@@ -78,7 +78,7 @@ export const saveDocumentVersion = async (req, res) => {
       groupId: id,
       versionName: versionName || `Version ${new Date().toLocaleString()}`,
       documentState: workspace.documentState,
-      savedBy: req.user.userId || req.user._id,
+      savedBy: req.user.id,
     });
     
     await version.save();

--- a/collegems-server/src/controllers/workflow.controller.js
+++ b/collegems-server/src/controllers/workflow.controller.js
@@ -13,7 +13,7 @@ export const createFormTemplate = async (req, res) => {
       name,
       description,
       fields,
-      createdBy: req.user._id, // Assuming req.user is populated by auth middleware
+      createdBy: req.user.id, // Assuming req.user is populated by auth middleware
     });
     res.status(201).json({ success: true, data: form });
   } catch (error) {
@@ -29,7 +29,7 @@ export const createWorkflowDef = async (req, res) => {
       category,
       description,
       formTemplate,
-      createdBy: req.user._id,
+      createdBy: req.user.id,
     });
     res.status(201).json({ success: true, data: workflowDef });
   } catch (error) {
@@ -76,7 +76,7 @@ export const getAvailableWorkflows = async (req, res) => {
 export const submitWorkflowRequest = async (req, res) => {
   try {
     const { workflowDefId, formData } = req.body;
-    const instance = await WorkflowEngine.startWorkflow(workflowDefId, req.user._id, formData);
+    const instance = await WorkflowEngine.startWorkflow(workflowDefId, req.user.id, formData);
     res.status(201).json({ success: true, data: instance });
   } catch (error) {
     res.status(400).json({ success: false, error: error.message });
@@ -85,7 +85,7 @@ export const submitWorkflowRequest = async (req, res) => {
 
 export const getMyRequests = async (req, res) => {
   try {
-    const requests = await WorkflowInstance.find({ requester: req.user._id })
+    const requests = await WorkflowInstance.find({ requester: req.user.id })
       .populate("workflowDef")
       .populate("currentStep");
     res.status(200).json({ success: true, data: requests });
@@ -123,7 +123,7 @@ export const processWorkflowAction = async (req, res) => {
     const { instanceId } = req.params;
     const { action, comments } = req.body; // "Approved" or "Rejected"
 
-    const instance = await WorkflowEngine.processAction(instanceId, req.user._id, action, comments);
+    const instance = await WorkflowEngine.processAction(instanceId, req.user.id, action, comments);
     res.status(200).json({ success: true, data: instance });
   } catch (error) {
     res.status(400).json({ success: false, error: error.message });

--- a/collegems-server/src/middlewares/audit.middleware.js
+++ b/collegems-server/src/middlewares/audit.middleware.js
@@ -24,7 +24,7 @@ export const auditAction = (actionName, moduleName) => {
           delete safeBody.confirmPassword;
 
           const logEntry = new AuditLog({
-            user: req.user ? (req.user.id || req.user._id) : null,
+            user: req.user ? req.user.id : null,
             action: actionName,
             module: moduleName,
             target: String(target),


### PR DESCRIPTION
## Summary
- \`generateAccessToken\`/\`generateRefreshToken\` (\`auth.controller.js\`) only ever encode \`id\` (never \`_id\`) into the JWT, and \`auth.middleware.js\` sets \`req.user = decoded\` directly — so \`req.user._id\` and \`req.user.userId\` are always \`undefined\` everywhere in the app.
- Every write using \`req.user._id\`/\`req.user.userId\` stored an \`undefined\` owner field (serialized to \`null\` by Mongoose), and every read filtering by that same undefined value had the field silently dropped from the query by Mongoose — matching **every** document instead of just the current user's, leaking every user's complaints, history, saved filters, and workflow requests to every other authenticated user.
- Fixed the genuinely-broken files (no fallback at all): \`complaint.controller.js\`, \`history.controller.js\`, \`savedFilter.controller.js\`, \`ownership.controller.js\`, \`workflow.controller.js\`, \`studyGroup.controller.js\` (this one used \`req.user.userId\` in 5 places, only 1 of which even had a — also broken — fallback).
- Also cleaned up \`clubs.controller.js\`, \`notification.controller.js\`, \`audit.middleware.js\`, and \`mentorship.controller.js\`, which already had a working \`|| req.user.id\` fallback (so not actually broken today) but still referenced the nonexistent field, to just \`req.user.id\` — matching the actual JWT payload contract per the issue's expected behavior.

I did not write a data-repair/migration script for already-corrupted null-owner documents. This is a pre-release project without a production deployment that has run the buggy code, so there's no evidence of existing corrupted data to repair — happy to add one if the maintainers know of a live database that needs it.

Fixes #578

## Test plan
- \`node --check\` on every changed file — no syntax errors.
- Ran the server locally against two real student accounts (A and B) through actual HTTP requests:
  - **Complaints**: A creates a complaint — stored with A's real user ID as \`student\` (not null). B's \`GET /api/complaints/my-complaints\` returns \`[]\`. A's returns exactly the 1 complaint they created.
  - **Saved filters**: A creates a saved filter — stored with A's real user ID as \`user\`. B's \`GET /api/saved-filters/student\` returns an empty list.
  - **History**: A records a history entry. B's \`GET /api/history\` returns \`[]\`. A's returns exactly the 1 entry they recorded.
- All three confirm the cross-user leak described in the issue is gone and each user only sees their own data.