### PR TITLE
fix: require staff confirmation before a fee payment counts as paid

### DIFF
--- a/collegems-client/src/App.tsx
+++ b/collegems-client/src/App.tsx
@@ -44,6 +44,7 @@ import AuditLogs from "./hod-components/AuditLogs";
 import ResourceBooking from "./user-components/ResourceBooking";
 import BookingManagement from "./hod-components/BookingManagement";
 import ResourceManagement from "./hod-components/ResourceManagement";
+import FeePaymentApprovals from "./hod-components/FeePaymentApprovals";
 import AnnouncementForm from "./common-components-management/AnnouncementForm";
 import AnnouncementManage from "./common-components-management/AnnouncementManage";
 
@@ -73,6 +74,7 @@ const HallAllocationGuarded = withRoleGuard(HallAllocation, { allowedRoles: User
 const AuditLogsGuarded = withRoleGuard(AuditLogs, { allowedRoles: UserRole.HOD });
 const BookingManagementGuarded = withRoleGuard(BookingManagement, { allowedRoles: UserRole.HOD });
 const ResourceManagementGuarded = withRoleGuard(ResourceManagement, { allowedRoles: UserRole.HOD });
+const FeePaymentApprovalsGuarded = withRoleGuard(FeePaymentApprovals, { allowedRoles: UserRole.HOD });
 const BulkFieldResetGuarded = withRoleGuard(BulkFieldReset, { allowedRoles: UserRole.HOD });
 
 const ParentDashboardGuarded = withRoleGuard(ParentDashboard, { allowedRoles: UserRole.PARENT });
@@ -188,6 +190,10 @@ export default function App() {
         <Route
           path="/hod/manage-resources"
           element={<ResourceManagementGuarded />}
+        />
+        <Route
+          path="/hod/fee-approvals"
+          element={<FeePaymentApprovalsGuarded />}
         />
         <Route
   path="/hod/student-transfer/:studentId"

--- a/collegems-client/src/hod-components/FeePaymentApprovals.tsx
+++ b/collegems-client/src/hod-components/FeePaymentApprovals.tsx
@@ -1,0 +1,158 @@
+import { useState, useEffect } from "react";
+import { isAxiosError } from "axios";
+import api from "../api/axios";
+import { extractArray } from "../utils/apiHelpers";
+import { CheckCircle, XCircle, Clock, Wallet } from "lucide-react";
+
+interface Installment {
+  _id: string;
+  amount: number;
+  paidOn: string;
+  status: "pending" | "confirmed" | "rejected";
+  requestedBy?: { name?: string; email?: string };
+}
+
+interface Fee {
+  _id: string;
+  student: { name?: string; email?: string; studentId?: string };
+  total: number;
+  paid: number;
+  installments: Installment[];
+}
+
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: "INR",
+    minimumFractionDigits: 0,
+  }).format(amount);
+
+export default function FeePaymentApprovals() {
+  const [fees, setFees] = useState<Fee[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actioningId, setActioningId] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const fetchPending = async () => {
+    try {
+      setLoading(true);
+      const res = await api.get("/fee/pending");
+      setFees(extractArray(res.data));
+    } catch (error) {
+      console.error("Failed to fetch pending fee payments", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPending();
+  }, []);
+
+  const handleReview = async (feeId: string, installmentId: string, action: "confirm" | "reject") => {
+    setActioningId(installmentId);
+    setMessage(null);
+    try {
+      await api.post(`/fee/installments/${feeId}/${installmentId}/${action}`);
+      setMessage({
+        type: "success",
+        text: action === "confirm" ? "Payment confirmed" : "Payment rejected",
+      });
+      await fetchPending();
+    } catch (error) {
+      const text = isAxiosError(error) ? error.response?.data?.message : undefined;
+      setMessage({
+        type: "error",
+        text: text || `Failed to ${action} payment`,
+      });
+    } finally {
+      setActioningId(null);
+    }
+  };
+
+  const pendingRows = fees.flatMap((fee) =>
+    fee.installments
+      .filter((installment) => installment.status === "pending")
+      .map((installment) => ({ fee, installment })),
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Fee Payment Approvals</h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          Students and parents submit payment claims here first - confirm or reject each one
+          before it counts toward the student's balance.
+        </p>
+      </div>
+
+      {message && (
+        <div
+          className={`p-4 rounded-lg text-sm ${
+            message.type === "success"
+              ? "bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-300 border border-green-200 dark:border-green-800"
+              : "bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300 border border-red-200 dark:border-red-800"
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+        {loading ? (
+          <div className="p-12 text-center text-gray-500 dark:text-gray-400">Loading...</div>
+        ) : pendingRows.length === 0 ? (
+          <div className="p-12 text-center">
+            <Wallet className="w-12 h-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
+            <p className="text-gray-500 dark:text-gray-400">No payments awaiting confirmation</p>
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100 dark:divide-gray-800">
+            {pendingRows.map(({ fee, installment }) => (
+              <div key={installment._id} className="p-4 flex items-center justify-between gap-4">
+                <div className="flex items-center gap-4">
+                  <div className="p-2 bg-amber-50 dark:bg-amber-900/30 rounded-lg">
+                    <Clock className="w-4 h-4 text-amber-600 dark:text-amber-400" />
+                  </div>
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {fee.student?.name || "Unknown student"}{" "}
+                      <span className="text-gray-400 font-normal">({fee.student?.studentId || fee.student?.email})</span>
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      Claims to have paid {formatCurrency(installment.amount)} on{" "}
+                      {new Date(installment.paidOn).toLocaleDateString("en-IN", {
+                        day: "numeric",
+                        month: "short",
+                        year: "numeric",
+                      })}
+                      {installment.requestedBy?.name ? ` · submitted by ${installment.requestedBy.name}` : ""}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    onClick={() => handleReview(fee._id, installment._id, "confirm")}
+                    disabled={actioningId === installment._id}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <CheckCircle className="w-4 h-4" />
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => handleReview(fee._id, installment._id, "reject")}
+                    disabled={actioningId === installment._id}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-red-700 bg-red-50 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-300 dark:hover:bg-red-900/40 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <XCircle className="w-4 h-4" />
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/collegems-client/src/user-components/Fee.tsx
+++ b/collegems-client/src/user-components/Fee.tsx
@@ -21,10 +21,10 @@ import api from "../api/axios";
 import { extractArray } from "../utils/apiHelpers";
 
 interface Installment {
+  _id?: string;
   amount: number;
   paidOn: string;
-  transactionId?: string;
-  paymentMethod?: string;
+  status?: "pending" | "confirmed" | "rejected";
 }
 
 interface Fee {
@@ -52,8 +52,8 @@ export default function StudentFee() {
   const fetchFee = async () => {
     try {
       setLoading(true);
-      const res = await api.get("/fee/me");
-      setFee(res.data);
+      const res = await api.get<{ data: Fee }>("/fee/me");
+      setFee(res.data.data);
       setMessage(null);
     } catch {
       setMessage({
@@ -90,7 +90,7 @@ export default function StudentFee() {
     setMessage(null);
 
     try {
-      const res = await api.post<{ fee: Fee; transactionId: string }>(
+      const res = await api.post<{ message: string; data: Fee }>(
         "/fee/pay",
         {
           amount: Number(amount),
@@ -98,11 +98,11 @@ export default function StudentFee() {
         },
       );
 
-      setFee(res.data.fee);
+      setFee(res.data.data);
       setAmount("");
       setMessage({
-        type: "success",
-        text: `Payment of ₹${amount} successful! Transaction ID: ${res.data.transactionId}`,
+        type: "info",
+        text: res.data.message,
       });
 
       setTimeout(() => {
@@ -493,7 +493,7 @@ export default function StudentFee() {
                   <div className="flex items-center gap-2 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
                     <Shield className="w-4 h-4 text-gray-500 dark:text-gray-400" />
                     <span className="text-xs text-gray-600 dark:text-gray-400">
-                      Secure payment powered by Razorpay
+                      Payments are reviewed and confirmed by the finance team before being applied to your balance.
                     </span>
                   </div>
 
@@ -549,7 +549,7 @@ export default function StudentFee() {
                 fee.installments
                   .slice(0, showPaymentHistory ? undefined : 5)
                   .map((installment, index) => (
-                    <div key={index} className="p-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                    <div key={installment._id || index} className="p-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
                       <div className="flex items-center justify-between">
                         <div className="flex items-center gap-4">
                           <div className="p-2 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
@@ -564,25 +564,23 @@ export default function StudentFee() {
                             </p>
                           </div>
                         </div>
-                        <div className="flex items-center gap-4">
-                          {installment.transactionId && (
-                            <span className="text-xs text-gray-400 dark:text-gray-500">
-                              ID: {installment.transactionId.slice(0, 8)}...
-                            </span>
-                          )}
+                        {installment.status === "pending" ? (
+                          <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">
+                            <Clock className="w-3 h-3 mr-1" />
+                            Pending confirmation
+                          </span>
+                        ) : installment.status === "rejected" ? (
+                          <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800">
+                            <XCircle className="w-3 h-3 mr-1" />
+                            Rejected
+                          </span>
+                        ) : (
                           <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-800">
                             <CheckCircle className="w-3 h-3 mr-1" />
-                            Success
+                            Confirmed
                           </span>
-                        </div>
+                        )}
                       </div>
-                      {installment.paymentMethod && (
-                        <div className="mt-2 ml-12">
-                          <span className="text-xs text-gray-400 dark:text-gray-500">
-                            Paid via {installment.paymentMethod}
-                          </span>
-                        </div>
-                      )}
                     </div>
                   ))
               ) : (

--- a/collegems-server/src/models/Fee.model.js
+++ b/collegems-server/src/models/Fee.model.js
@@ -1,19 +1,37 @@
 import mongoose from "mongoose";
 
-const installmentSchema = new mongoose.Schema(
-  {
-    amount: {
-      type: Number,
-      required: true,
-      min: 0,
-    },
-    paidOn: {
-      type: Date,
-      default: Date.now,
-    },
+const installmentSchema = new mongoose.Schema({
+  amount: {
+    type: Number,
+    required: true,
+    min: 0,
   },
-  { _id: false },
-);
+  paidOn: {
+    type: Date,
+    default: Date.now,
+  },
+  // Payments submitted by a student/parent start as "pending" and only
+  // count toward `paid` once a staff member (hod) confirms them - see
+  // POST /api/fee/pay vs POST /api/fee/installments/:feeId/:installmentId/confirm.
+  // Installments created directly by staff (e.g. via /fee/set or the seeder)
+  // default to "confirmed" since there's nothing to verify.
+  status: {
+    type: String,
+    enum: ["pending", "confirmed", "rejected"],
+    default: "confirmed",
+  },
+  requestedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+  },
+  confirmedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+  },
+  confirmedAt: {
+    type: Date,
+  },
+});
 
 const feeSchema = new mongoose.Schema(
   {

--- a/collegems-server/src/routes/fee.routes.js
+++ b/collegems-server/src/routes/fee.routes.js
@@ -46,7 +46,11 @@ router.post(
   })
 );
 
-// installment pay
+// Submit a payment claim. This does NOT mark the fee as paid - there is no
+// payment-gateway integration, so a self-reported amount from the paying
+// party can't be trusted on its own. It records a "pending" installment that
+// a staff member (hod) must confirm via /installments/:feeId/:installmentId/confirm
+// before it counts toward the balance.
 router.post("/pay", protect, allowRoles("student", "parent"), asyncHandler(async (req, res) => {
   const { amount } = req.body;
   if (!amount || amount <= 0) {
@@ -71,17 +75,109 @@ router.post("/pay", protect, allowRoles("student", "parent"), asyncHandler(async
     throw new AppError("Fee record not found", 404, "NOT_FOUND");
   }
 
-  fee.installments.push({ amount });
-  fee.paid += amount;
+  if (amount > fee.total - fee.paid) {
+    throw new AppError("Amount cannot exceed the remaining balance", 400, "INVALID_AMOUNT");
+  }
+
+  fee.installments.push({ amount, status: "pending", requestedBy: req.user.id });
   await fee.save();
 
-  log.info(`Payment made: ${amount}`, { studentId, feeId: fee._id });
+  await logAction(req.user.id, "REQUEST_FEE_PAYMENT", "Fee", fee._id, { studentId, amount });
+
+  log.info(`Payment claim submitted: ${amount}`, { studentId, feeId: fee._id });
   res.json({
     success: true,
-    message: "Payment successful",
+    message: "Payment submitted and is pending confirmation by the finance team",
     data: fee,
   });
 }));
+
+// List every fee with at least one payment awaiting confirmation.
+router.get(
+  "/pending",
+  protect,
+  allowRoles("hod"),
+  asyncHandler(async (req, res) => {
+    const fees = await Fee.find({ "installments.status": "pending" })
+      .populate("student", "name email studentId")
+      .populate("installments.requestedBy", "name email");
+    res.json({ success: true, data: fees });
+  })
+);
+
+// Confirm a pending payment claim: only now does it count toward the balance.
+router.post(
+  "/installments/:feeId/:installmentId/confirm",
+  protect,
+  allowRoles("hod"),
+  asyncHandler(async (req, res) => {
+    const { feeId, installmentId } = req.params;
+    const fee = await Fee.findById(feeId);
+    if (!fee) {
+      throw new AppError("Fee record not found", 404, "NOT_FOUND");
+    }
+
+    const installment = fee.installments.id(installmentId);
+    if (!installment) {
+      throw new AppError("Payment not found", 404, "NOT_FOUND");
+    }
+    if (installment.status !== "pending") {
+      throw new AppError("This payment has already been reviewed", 409, "ALREADY_REVIEWED");
+    }
+
+    installment.status = "confirmed";
+    installment.confirmedBy = req.user.id;
+    installment.confirmedAt = new Date();
+    fee.paid += installment.amount;
+    await fee.save();
+
+    await logAction(req.user.id, "CONFIRM_FEE_PAYMENT", "Fee", fee._id, {
+      installmentId,
+      amount: installment.amount,
+      studentId: fee.student,
+    });
+
+    log.info(`Payment confirmed: ${installment.amount}`, { feeId: fee._id, installmentId });
+    res.json({ success: true, message: "Payment confirmed", data: fee });
+  })
+);
+
+// Reject a pending payment claim (e.g. a bogus/duplicate self-report).
+// No balance change - just marks it so it's no longer awaiting review.
+router.post(
+  "/installments/:feeId/:installmentId/reject",
+  protect,
+  allowRoles("hod"),
+  asyncHandler(async (req, res) => {
+    const { feeId, installmentId } = req.params;
+    const fee = await Fee.findById(feeId);
+    if (!fee) {
+      throw new AppError("Fee record not found", 404, "NOT_FOUND");
+    }
+
+    const installment = fee.installments.id(installmentId);
+    if (!installment) {
+      throw new AppError("Payment not found", 404, "NOT_FOUND");
+    }
+    if (installment.status !== "pending") {
+      throw new AppError("This payment has already been reviewed", 409, "ALREADY_REVIEWED");
+    }
+
+    installment.status = "rejected";
+    installment.confirmedBy = req.user.id;
+    installment.confirmedAt = new Date();
+    await fee.save();
+
+    await logAction(req.user.id, "REJECT_FEE_PAYMENT", "Fee", fee._id, {
+      installmentId,
+      amount: installment.amount,
+      studentId: fee.student,
+    });
+
+    log.info(`Payment rejected`, { feeId: fee._id, installmentId });
+    res.json({ success: true, message: "Payment rejected", data: fee });
+  })
+);
 
 router.get("/me", protect, allowRoles("student", "parent"), asyncHandler(async (req, res) => {
   let studentId = req.user.id;


### PR DESCRIPTION
## Summary
- \`POST /api/fee/pay\` let a student/parent mark their own tuition fee as paid with no verification: the client-supplied \`amount\` was trusted directly and immediately credited (\`fee.paid += amount\`), with no payment gateway, transaction ID, or approval step anywhere in the server. A student could self-certify their own payment.
- There's no real payment-gateway integration in this project to verify a transaction against (no Razorpay/Stripe/webhook handling exists), so per the issue's own suggested alternative, this implements the **explicit staff confirmation** path instead of a real gateway integration:
  - \`Fee.model.js\`: each installment now carries a \`status\` (\`"pending"\` by default for self-reported payments via \`/fee/pay\`, \`"confirmed"\` by default for anything staff create directly via \`/fee/set\` or the seeder - so existing data stays backward compatible), plus \`requestedBy\`/\`confirmedBy\`/\`confirmedAt\` for an audit trail.
  - \`POST /api/fee/pay\` now records a \`"pending"\` installment claim without touching \`fee.paid\`/\`status\` at all.
  - New hod-only endpoints: \`GET /api/fee/pending\` (queue of unconfirmed claims across all students), \`POST /api/fee/installments/:feeId/:installmentId/confirm\` (only this actually applies \`fee.paid += amount\`), and the \`.../reject\` counterpart (dismiss a bogus/duplicate claim, no balance change). Both actions are audit-logged via the existing \`logAction\` utility.
  - New client page \`hod-components/FeePaymentApprovals.tsx\`, routed at \`/hod/fee-approvals\` (hod-only), so the confirm/reject step is actually usable through the app rather than being an orphaned API.
  - \`user-components/Fee.tsx\` updated to match the real API response shape (it was previously reading \`res.data.fee\`/\`res.data.transactionId\`, which never existed - a pre-existing dead-code bug I had to fix to make this testable), show pending/confirmed/rejected status per payment, and replaced the false "Secure payment powered by Razorpay" claim with accurate messaging about staff review.

Fixes #579

## Test plan
- Backend, via real HTTP requests against a running server with two accounts (hod + student):
  - Student submits a ₹5,000 claim on a ₹10,000 fee → \`fee.paid\` stays \`0\`, installment status \`"pending"\`.
  - Student's own \`GET /fee/me\` still shows the fee as unpaid.
  - Student attempting to hit the confirm endpoint directly → \`403 Forbidden\` (role-gated).
  - HOD confirms → \`fee.paid\` becomes \`5000\`, status \`"Partial"\`.
  - Confirming the same installment again → \`409 ALREADY_REVIEWED\`.
  - Separately verified reject: HOD rejects a claim → \`fee.paid\` stays \`0\`, installment status \`"rejected"\`.
- Frontend, driven through a real browser end-to-end:
  - Logged in as a student, opened the Fees tab, submitted a ₹4,000 payment through the actual form — UI shows "Payment submitted and is pending confirmation by the finance team" and **Paid Amount stays ₹0** (previously it would have shown "Payment successful").
  - Logged in as HOD, opened \`/hod/fee-approvals\` — saw the pending claim listed with student name and amount.
  - Clicked "Confirm" through the real UI — claim disappeared from the queue with a "Payment confirmed" message.