### PR TITLE
fix: restrict library fine payment to staff, no more unconditional mock flip

### DIFF
--- a/collegems-server/src/controllers/library.controller.js
+++ b/collegems-server/src/controllers/library.controller.js
@@ -3,6 +3,7 @@ import BookIssue from "../models/BookIssue.model.js";
 import User from "../models/User.model.js";
 import LibraryFine from "../models/LibraryFine.model.js";
 import Notification from "../models/Notification.model.js";
+import { logAction } from "../utils/auditService.js";
 
 // GET ALL BOOKS
 export const getAllBooks = async (req, res) => {
@@ -269,7 +270,11 @@ export const getUserFines = async (req, res) => {
   }
 };
 
-// PAY LIBRARY FINE (MOCK PAYMENT)
+// RECORD A LIBRARY FINE AS PAID
+// Restricted to hod/teacher (see library.routes.js) - the librarian collects
+// the fine in person and records it here. There's no payment gateway, so this
+// must stay a staff-confirmed action rather than something the paying student
+// can trigger themselves.
 export const payLibraryFine = async (req, res) => {
   try {
     const { fineId } = req.params;
@@ -283,10 +288,14 @@ export const payLibraryFine = async (req, res) => {
       return res.status(400).json({ success: false, message: "Fine is already paid" });
     }
 
-    // Mocking successful payment
     fine.status = "Paid";
     fine.paidOn = new Date();
     await fine.save();
+
+    await logAction(req.user.id, "PAY_LIBRARY_FINE", "LibraryFine", fine._id, {
+      studentId: fine.student._id,
+      amount: fine.amount,
+    });
 
     // Create Notification for successful payment
     const notification = new Notification({

--- a/collegems-server/src/routes/library.routes.js
+++ b/collegems-server/src/routes/library.routes.js
@@ -28,6 +28,9 @@ router.post("/return/:issueId", protect, allowRoles("hod", "teacher"), returnBoo
 
 // Fine Management Routes
 router.get("/fines", protect, getUserFines);
-router.post("/fines/:fineId/pay", protect, payLibraryFine);
+// Marking a fine paid is a staff action (the librarian collects the fine and
+// records it here) - there's no payment gateway, so a self-service "pay" call
+// from the student themselves can't be trusted as proof of payment.
+router.post("/fines/:fineId/pay", protect, allowRoles("hod", "teacher"), payLibraryFine);
 
 export default router;


### PR DESCRIPTION
## Summary
- \`POST /api/library/fines/:fineId/pay\` was guarded only by \`protect\` (any authenticated user) - no \`allowRoles(...)\`, and the controller never checked \`fine.student._id.toString() === req.user.id\`. Any authenticated user could mark any other student's library fine as paid, and the "payment" was an unconditional mock flip (\`fine.status = "Paid"\`) with nothing behind it - no gateway, no transaction record, no approval step.
- There's no library frontend UI wired to this endpoint yet, and no payment-gateway integration in this project to verify a real transaction against, so per the issue's own suggested fix ("restrict to staff/admin roles"), \`payLibraryFine\` is now restricted to \`allowRoles("hod", "teacher")\` - matching every other library-management route in \`library.routes.js\` (add/update/delete book, issue, return). Marking a fine paid becomes a librarian recording an in-person payment rather than a self-service action the paying (or any) student can trigger.
- Also added audit logging (\`logAction\`) for the action, consistent with other sensitive actions elsewhere in the codebase.

Fixes #580

## Test plan
- Ran the server locally and exercised the endpoint with real accounts and a seeded fine:
  - The fine's own student tries to pay it → \`403 Forbidden\`.
  - A second, unrelated student tries to pay the first student's fine → \`403 Forbidden\`.
  - Confirmed in the database the fine status is still \`"Unpaid"\` after both attempts.
  - A teacher account calls the same endpoint → \`200\`, fine correctly marked \`"Paid"\`.