### PR TITLE
fix: stop building resume upload filenames from attacker-controlled originalname

### DIFF
--- a/collegems-server/src/middlewares/upload.middleware.js
+++ b/collegems-server/src/middlewares/upload.middleware.js
@@ -53,7 +53,11 @@ const resumeStorage = multer.diskStorage({
     cb(null, "uploads/resumes/");
   },
   filename: (req, file, cb) => {
-    cb(null, `${Date.now()}-${file.originalname.replace(/\s+/g, '-')}`); 
+    // Never derive the on-disk filename from the attacker-controlled
+    // originalname (e.g. "../../../server.js") - generate one and rely on
+    // resumeFilter below to guarantee the upload is a PDF.
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    cb(null, `${uniqueSuffix}.pdf`);
   },
 });
 


### PR DESCRIPTION
## Summary
- The resume-upload filename callback (\`upload.middleware.js\`) built the on-disk filename with \`\`\`Date.now()}-\${file.originalname.replace(/\s+/g, '-')}\`\`\` - only whitespace was stripped, with no path-traversal sanitization. Multer's disk storage joins \`destination\` and the returned \`filename\` with \`path.join\` and doesn't validate the result stays within \`destination\`, so a crafted \`originalname\` like \`../../../server.js\` let an authenticated student/alumni user write arbitrary content outside \`uploads/resumes/\`, including overwriting application source files.
- Per the issue's suggested fix, stopped deriving the filename from user input at all: generate a random timestamp-based name and always use a \`.pdf\` extension. This is safe because \`resumeFilter\` (registered on the same multer instance) already rejects any upload whose MIME type isn't \`application/pdf\` before the \`filename\` callback ever runs, so the extension is always predictable.

Fixes #583

## Test plan
Ran the server locally and reproduced the exact exploit from the issue:
- Logged in as a real student account.
- Uploaded a multipart file with \`Content-Type: application/pdf\` (passes \`resumeFilter\`) and \`filename\` set to \`../../../server.js\`, with payload content \`"...EXPLOIT PAYLOAD..."\`.
- Upload succeeded (\`200\`), but:
  - \`server.js\`'s content and md5 hash are **unchanged** - confirmed the exploit did not escape the resumes directory.
  - The uploaded file landed safely inside \`uploads/resumes/\` under a generated name (e.g. \`1783589112105-662998131.pdf\`) with no path-traversal characters.
  - The returned \`resumeUrl\` correctly points inside \`/uploads/resumes/\`.