### PR TITLE
fix: verify caller has a legitimate relationship to a resource before minting a temporary link

### DIFF
--- a/collegems-server/src/controllers/temporaryLink.controller.js
+++ b/collegems-server/src/controllers/temporaryLink.controller.js
@@ -12,9 +12,9 @@ export const generateLink = async (req, res) => {
     }
 
     const link = await tempLinkService.generateLink(
-      resourceType, 
-      resourceId, 
-      req.user.id, 
+      resourceType,
+      resourceId,
+      req.user,
       expiresInMinutes || 60
     );
 
@@ -32,6 +32,9 @@ export const generateLink = async (req, res) => {
       }
     });
   } catch (error) {
+    if (error.message === "Not authorized to share a link to this resource") {
+      return res.status(403).json({ message: error.message });
+    }
     if (error.message.includes("Unsupported resource type") || error.message.includes("not found")) {
       return res.status(400).json({ message: error.message });
     }

--- a/collegems-server/src/services/temporaryLink.service.js
+++ b/collegems-server/src/services/temporaryLink.service.js
@@ -1,19 +1,53 @@
 import crypto from "crypto";
 import mongoose from "mongoose";
 import TemporaryLink from "../models/TemporaryLink.model.js";
+import Course from "../models/Course.model.js";
+import User from "../models/User.model.js";
 
 // Configured valid resource types for security
 export const SUPPORTED_RESOURCE_TYPES = ["Resource", "Book", "ExamSchedule", "Assignment"];
 
 /**
+ * Verify the requesting user actually has a legitimate relationship to the
+ * resource before a shareable link is minted for it. Staff (hod/admin)
+ * always pass. Per resource type:
+ *  - Assignment: the assignment's own teacher, or a student enrolled in its
+ *    course (matched the same way results.controller.js checks eligibility).
+ *  - Resource/Book/ExamSchedule: none of these carry a per-user ownership or
+ *    enrollment relationship in their schema, so only staff may share them.
+ */
+const authorizeResourceAccess = async (resourceType, resource, requestingUser) => {
+  if (requestingUser.role === "hod" || requestingUser.role === "admin") {
+    return;
+  }
+
+  if (resourceType === "Assignment") {
+    if (requestingUser.role === "teacher" && resource.teacher && resource.teacher.toString() === requestingUser.id) {
+      return;
+    }
+    if (requestingUser.role === "student" && resource.course) {
+      const course = await Course.findById(resource.course);
+      const student = await User.findById(requestingUser.id);
+      const matchesSem = course && student?.semester && course.semester === Number(student.semester);
+      const matchesDept = course && student?.course && course.department?.toLowerCase() === student.course.toLowerCase();
+      if (matchesSem || matchesDept) {
+        return;
+      }
+    }
+  }
+
+  throw new Error("Not authorized to share a link to this resource");
+};
+
+/**
  * Generate a new temporary link
- * @param {string} resourceType 
- * @param {string} resourceId 
- * @param {string} createdBy 
- * @param {number} expiresInMinutes 
+ * @param {string} resourceType
+ * @param {string} resourceId
+ * @param {Object} requestingUser
+ * @param {number} expiresInMinutes
  * @returns {Object} The created link
  */
-export const generateLink = async (resourceType, resourceId, createdBy, expiresInMinutes = 60) => {
+export const generateLink = async (resourceType, resourceId, requestingUser, expiresInMinutes = 60) => {
   if (!SUPPORTED_RESOURCE_TYPES.includes(resourceType)) {
     throw new Error(`Unsupported resource type: ${resourceType}`);
   }
@@ -29,6 +63,9 @@ export const generateLink = async (resourceType, resourceId, createdBy, expiresI
     throw new Error(`${resourceType} with ID ${resourceId} not found`);
   }
 
+  await authorizeResourceAccess(resourceType, resource, requestingUser);
+
+  const createdBy = requestingUser.id;
   const token = crypto.randomBytes(32).toString("hex");
   const expiresAt = new Date(Date.now() + expiresInMinutes * 60 * 1000);
 


### PR DESCRIPTION
## Summary
- \`generateLink\` (\`temporaryLink.service.js\`) only checked that \`resourceType\` was whitelisted and that the target document existed. \`createdBy\` was recorded on the link but never used to authorize the *creation* of the link, and \`POST /api/temporary-links\` accepted any authenticated user of any role. Combined with the fully public \`GET /access/:token\` endpoint, this let any authenticated user mint a shareable public link to any other user's data — e.g. a student generating a link to a different course's assignment and reading every student's submissions, files, and marks with no further auth.
- Added \`authorizeResourceAccess\`, checked before a link is created:
  - Staff (\`hod\`/\`admin\`) always pass, matching how other write endpoints in this codebase treat staff.
  - **Assignment**: the assignment's own \`teacher\`, or a student enrolled in its \`course\` (matched the same way \`results.controller.js\`'s \`createResult\` already checks eligibility — semester or department match).
  - **Resource / Book / ExamSchedule**: none of these carry a per-user ownership or enrollment relationship in their schema (no student/teacher field to check against), so only staff may share them.
- The read side (\`GET /access/:token\`) is intentionally unchanged and stays public once a link has been legitimately minted — that's the point of a shareable link. This fix closes the *minting* step, which is where the issue actually is.

Fixes #584

## Test plan
Ran the server locally with real accounts (HOD, two teachers, two students in different courses/departments) and exercised every combination via real HTTP requests:
- A student outside the assignment's course tries to generate a link → \`403\`.
- A student actually enrolled in the assignment's course → \`201\`.
- The assignment's own teacher → \`201\`.
- A different teacher (not the owner) → \`403\`.
- HOD → \`201\` (staff bypass).
- A student trying to link a \`Resource\` (no ownership concept) → \`403\`.
- A teacher trying to link the same \`Resource\` → \`403\` (staff-only type, teacher isn't hod/admin).
- HOD linking the same \`Resource\` → \`201\`.
- Confirmed the legitimately-created link still works end-to-end: \`GET /access/:token\` with no auth returns \`200\` with the full resource (including submissions) — the read path is untouched.