### PR TITLE
fix: add course-ownership check to internal assessment endpoints (IDOR)

### DIFF
--- a/collegems-server/src/controllers/assessment.controller.js
+++ b/collegems-server/src/controllers/assessment.controller.js
@@ -23,6 +23,14 @@ export const saveAssessmentConfig = async (req, res) => {
         const { courseId } = req.params;
         const { components } = req.body;
 
+        const course = await Course.findById(courseId);
+        if (!course) {
+            return res.status(404).json({ message: "Course not found" });
+        }
+        if (req.user.role === "teacher" && course.teacher.toString() !== req.user.id) {
+            return res.status(403).json({ message: "Not authorized to manage assessments for this course" });
+        }
+
         const totalWeightage = components.reduce((sum, comp) => sum + Number(comp.weightage), 0);
         if (totalWeightage !== 100) {
             return res.status(400).json({ message: "Total weightage must be exactly 100%" });
@@ -59,6 +67,14 @@ export const saveInternalAssessment = async (req, res) => {
     try {
         const { courseId, studentId } = req.params;
         const { scores } = req.body; // Array of { componentName, score }
+
+        const course = await Course.findById(courseId);
+        if (!course) {
+            return res.status(404).json({ message: "Course not found" });
+        }
+        if (req.user.role === "teacher" && course.teacher.toString() !== req.user.id) {
+            return res.status(403).json({ message: "Not authorized to manage assessments for this course" });
+        }
 
         const config = await AssessmentConfig.findOne({ courseId });
         if (!config) {


### PR DESCRIPTION
## Summary
- \`saveInternalAssessment\` and \`saveAssessmentConfig\` (\`assessment.controller.js\`, routed via \`assessment.routes.js\` with only \`allowRoles('teacher', 'admin')\`) had no check that the requesting teacher actually teaches the target course — unlike \`createResult\`, which already checks \`course.teacher.toString() !== req.user.id\`. Any authenticated teacher, regardless of assignment, could overwrite another teacher's students' internal marks for a course they don't teach, or rewrite another teacher's grading-component weightages entirely (a classic IDOR).
- Both handlers now resolve the course and verify the requesting teacher owns it (teacher role only — \`admin\` still bypasses, mirroring how \`createResult\` treats non-teacher roles) before allowing the write, matching the existing pattern in \`results.controller.js\`.

Fixes #585

## Test plan
Ran the server locally with two teacher accounts (one assigned to the course, one not) and a real course/student:
- The unassigned ("intruder") teacher calling \`POST /api/assessments/config/:courseId\` → \`403\`.
- The unassigned teacher calling \`POST /api/assessments/marks/:courseId/:studentId\` → \`403\`.
- The actual course owner calling both endpoints → \`200\` in both cases, confirming legitimate teachers are unaffected.