### PR TITLE
Validate internal assessment scores against component maxMarks

### DIFF
--- a/collegems-server/src/controllers/assessment.controller.js
+++ b/collegems-server/src/controllers/assessment.controller.js
@@ -65,15 +65,26 @@ export const saveInternalAssessment = async (req, res) => {
             return res.status(400).json({ message: "Assessment configuration not set for this course." });
         }
 
+        // Validate scores against configured components before computing totals
+        for (const s of scores) {
+            const compConfig = config.components.find(c => c.name === s.componentName);
+            if (!compConfig) {
+                return res.status(400).json({ message: `Unknown assessment component: ${s.componentName}` });
+            }
+            if (s.score < 0 || s.score > compConfig.maxMarks) {
+                return res.status(400).json({
+                    message: `Score for ${s.componentName} must be between 0 and ${compConfig.maxMarks}`
+                });
+            }
+        }
+
         // Calculate total internal marks
         let totalInternalMarks = 0;
         for (const s of scores) {
             const compConfig = config.components.find(c => c.name === s.componentName);
-            if (compConfig) {
-                // Formula: (score / maxMarks) * weightage
-                const computedMark = (s.score / compConfig.maxMarks) * compConfig.weightage;
-                totalInternalMarks += computedMark;
-            }
+            // Formula: (score / maxMarks) * weightage
+            const computedMark = (s.score / compConfig.maxMarks) * compConfig.weightage;
+            totalInternalMarks += computedMark;
         }
 
         let assessment = await InternalAssessment.findOne({ courseId, studentId });

--- a/collegems-server/src/tests/assessment.test.js
+++ b/collegems-server/src/tests/assessment.test.js
@@ -1,0 +1,79 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+import AssessmentConfig from '../models/AssessmentConfig.model.js';
+import InternalAssessment from '../models/InternalAssessment.model.js';
+import { saveInternalAssessment } from '../controllers/assessment.controller.js';
+
+let mongoServer;
+
+function mockRes() {
+    const res = {};
+    res.status = (code) => { res.statusCode = code; return res; };
+    res.json = (payload) => { res.body = payload; return res; };
+    return res;
+}
+
+describe('Internal Assessment Score Validation', () => {
+    let courseId;
+    let studentId;
+
+    before(async () => {
+        mongoServer = await MongoMemoryServer.create();
+        await mongoose.connect(mongoServer.getUri());
+    });
+
+    after(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+    });
+
+    beforeEach(async () => {
+        courseId = new mongoose.Types.ObjectId();
+        studentId = new mongoose.Types.ObjectId();
+
+        await AssessmentConfig.create({
+            courseId,
+            components: [
+                { name: 'Assignment', weightage: 20, maxMarks: 20 },
+                { name: 'Midterm', weightage: 80, maxMarks: 50 }
+            ]
+        });
+    });
+
+    it('rejects a score greater than the component maxMarks', async () => {
+        const req = { params: { courseId: String(courseId), studentId: String(studentId) }, body: { scores: [{ componentName: 'Assignment', score: 5000 }] } };
+        const res = mockRes();
+
+        await saveInternalAssessment(req, res);
+
+        assert.strictEqual(res.statusCode, 400);
+        const saved = await InternalAssessment.findOne({ courseId, studentId });
+        assert.strictEqual(saved, null);
+    });
+
+    it('rejects an unknown component name', async () => {
+        const req = { params: { courseId: String(courseId), studentId: String(studentId) }, body: { scores: [{ componentName: 'Bogus', score: 5 }] } };
+        const res = mockRes();
+
+        await saveInternalAssessment(req, res);
+
+        assert.strictEqual(res.statusCode, 400);
+    });
+
+    it('accepts valid scores and computes the weighted total', async () => {
+        const req = {
+            params: { courseId: String(courseId), studentId: String(studentId) },
+            body: { scores: [{ componentName: 'Assignment', score: 10 }, { componentName: 'Midterm', score: 25 }] }
+        };
+        const res = mockRes();
+
+        await saveInternalAssessment(req, res);
+
+        assert.strictEqual(res.statusCode, 200);
+        const expected = (10 / 20) * 20 + (25 / 50) * 80;
+        assert.strictEqual(res.body.assessment.totalInternalMarks, expected);
+    });
+});


### PR DESCRIPTION
## Summary
- `saveInternalAssessment` computed the weighted internal total straight from client-submitted scores without checking them against the component's configured `maxMarks`, so an out-of-range score (e.g. 5000 on a 20-mark component) inflated `totalInternalMarks` far beyond the intended 0-100 scale.
- Each submitted score is now validated against its component's `maxMarks` (0 ≤ score ≤ maxMarks) and the component name is checked to exist in the course's assessment config; invalid submissions are rejected with a 400 before any total is computed.

Fixes #590

## Test plan
- [x] Added `collegems-server/src/tests/assessment.test.js` covering: score exceeding maxMarks is rejected, unknown component name is rejected, valid scores compute the correct weighted total
- [x] `node --test src/tests/assessment.test.js` passes