### PR TITLE
Validate result marks fields against sensible min/max bounds

### DIFF
--- a/collegems-server/src/controllers/results.controller.js
+++ b/collegems-server/src/controllers/results.controller.js
@@ -3,6 +3,13 @@ import Student from "../models/User.model.js";
 import Course from "../models/Course.model.js";
 import { logAction } from "../utils/auditService.js";
 
+const MAX_COMPONENT_MARKS = 100;
+
+// A component mark is valid if it's omitted, or a finite number within [0, MAX_COMPONENT_MARKS].
+const isValidComponentMark = (marks) =>
+    marks === undefined || marks === null ||
+    (typeof marks === "number" && Number.isFinite(marks) && marks >= 0 && marks <= MAX_COMPONENT_MARKS);
+
 export const getResults = async (req, res) => {
     try {
         if (!req.user) {
@@ -50,10 +57,17 @@ export const createResult = async (req, res) => {
             internalMarks,
             externalMarks,
             practicalMarks,
-            totalMarks,
             grade,
             status,
         } = req.body;
+
+        if (![internalMarks, externalMarks, practicalMarks].every(isValidComponentMark)) {
+            return res.status(400).json({
+                message: `Marks fields must be numbers between 0 and ${MAX_COMPONENT_MARKS}`,
+            });
+        }
+
+        const totalMarks = (internalMarks || 0) + (externalMarks || 0) + (practicalMarks || 0);
 
         const student = await Student.findById(studentId);
         if (!student) {
@@ -146,6 +160,9 @@ export const publishResult = async (req, res) => {
         });
     } catch (error) {
         console.error("Publish Result Error:", error);
+        if (error.name === "ValidationError") {
+            return res.status(400).json({ message: "Cannot publish a result with invalid marks", error: error.message });
+        }
         res.status(500).json({ message: "Publish failed" });
     }
 };
@@ -191,20 +208,35 @@ export const publishAll = async (req, res) => {
             return res.json({ success: true, message: "No draft results to publish", count: 0 });
         }
 
-        await Results.updateMany(filter, { $set: { status: "published" } });
+        const publishable = drafts.filter((d) =>
+            isValidComponentMark(d.internalMarks) &&
+            isValidComponentMark(d.externalMarks) &&
+            isValidComponentMark(d.practicalMarks)
+        );
+        const skipped = drafts.length - publishable.length;
+
+        if (publishable.length === 0) {
+            return res.json({ success: true, message: "No draft results with valid marks to publish", count: 0, skipped });
+        }
+
+        await Results.updateMany(
+            { _id: { $in: publishable.map((d) => d._id) } },
+            { $set: { status: "published" } }
+        );
 
         res.json({
             success: true,
-            message: `Published ${drafts.length} result(s)`,
-            count: drafts.length,
+            message: `Published ${publishable.length} result(s)`,
+            count: publishable.length,
+            skipped,
         });
 
         // Log bulk publish with rich audit details
         await logAction(req.user.id, "PUBLISH_ALL_RESULTS", "Result", null, {
             userRole: req.user.role,
             filter: { courseId: courseId || null, semester: semester || null },
-            publishedCount: drafts.length,
-            resultIds: drafts.map((r) => r._id),
+            publishedCount: publishable.length,
+            resultIds: publishable.map((r) => r._id),
         });
     } catch (error) {
         console.error("Publish All Error:", error);

--- a/collegems-server/src/models/Results.model.js
+++ b/collegems-server/src/models/Results.model.js
@@ -18,11 +18,11 @@ const ResultsSchema = new mongoose.Schema({
         type: String,
     },
 
-    internalMarks: Number,
-    externalMarks: Number,
-    practicalMarks: Number,
+    internalMarks: { type: Number, min: 0, max: 100 },
+    externalMarks: { type: Number, min: 0, max: 100 },
+    practicalMarks: { type: Number, min: 0, max: 100 },
 
-    totalMarks: Number,
+    totalMarks: { type: Number, min: 0, max: 300 },
 
     grade: {
         type: String,

--- a/collegems-server/src/tests/results.test.js
+++ b/collegems-server/src/tests/results.test.js
@@ -304,4 +304,56 @@ test("Exam Results Authorization & Integrity API Tests", async (t) => {
     assert.ok(result.semester !== undefined);
     assert.ok(result.courseId !== null);
   });
+
+  await t.test("POST /create should reject a negative internalMarks value", async () => {
+    const res = await request(app)
+      .post("/api/results/create")
+      .set("Authorization", `Bearer ${teacher1Token}`)
+      .send({
+        studentId: studentUser._id,
+        courseId: course1._id,
+        semester: "3",
+        internalMarks: -20,
+        externalMarks: 50,
+        grade: "A++",
+      });
+
+    assert.strictEqual(res.status, 400);
+    assert.match(res.body.message, /between 0 and 100/i);
+  });
+
+  await t.test("POST /create should reject a component mark above 100", async () => {
+    const res = await request(app)
+      .post("/api/results/create")
+      .set("Authorization", `Bearer ${teacher1Token}`)
+      .send({
+        studentId: studentUser._id,
+        courseId: course1._id,
+        semester: "3",
+        internalMarks: 20,
+        externalMarks: 9999,
+        grade: "A++",
+      });
+
+    assert.strictEqual(res.status, 400);
+    assert.match(res.body.message, /between 0 and 100/i);
+  });
+
+  await t.test("POST /create should ignore a client-supplied totalMarks and recompute it server-side", async () => {
+    const res = await request(app)
+      .post("/api/results/create")
+      .set("Authorization", `Bearer ${teacher1Token}`)
+      .send({
+        studentId: studentUser._id,
+        courseId: course1._id,
+        semester: "3",
+        internalMarks: 20,
+        externalMarks: 50,
+        totalMarks: 9999,
+        grade: "B",
+      });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.totalMarks, 70);
+  });
 });


### PR DESCRIPTION
## Summary
- `Results.model.js` placed no bounds on `internalMarks`, `externalMarks`, `practicalMarks`, `totalMarks`, and `createResult` performed no range validation, so a result could be created (and later published) with e.g. `internalMarks: -20, totalMarks: 9999`.
- Added schema-level `min`/`max` bounds on the component mark fields (0-100, matching the 100-point scale already assumed by the grade table and student percentage calculation elsewhere in the app) and a `totalMarks` cap.
- `createResult` now rejects any component mark outside 0-100 with a 400, and recomputes `totalMarks` server-side from the validated components instead of trusting the client-submitted value.
- `publishResult` returns a 400 (instead of a raw 500) if the record fails schema validation on save, and `publishAll` now skips (and reports as `skipped`) any draft with out-of-range marks instead of blindly publishing it.

Fixes #591

## Test plan
- [x] Added tests in `collegems-server/src/tests/results.test.js`: negative `internalMarks` rejected, a component mark above 100 rejected, and a client-supplied bogus `totalMarks` is ignored/recomputed correctly
- [x] `node --test src/tests/results.test.js` — all 12 tests pass (existing + new)