### PR TITLE
Reject negative and zero scholarship amounts

### DIFF
--- a/collegems-client/src/common-components-management/Scholarships.tsx
+++ b/collegems-client/src/common-components-management/Scholarships.tsx
@@ -99,6 +99,11 @@ export default function Scholarships() {
       return;
     }
 
+    if (Number(formData.amount) <= 0) {
+      alert("Amount must be a positive number.");
+      return;
+    }
+
     try {
       setSubmitting(true);
       await api.post("/scholarships", {
@@ -415,6 +420,7 @@ export default function Scholarships() {
                   <input
                     type="number"
                     name="amount"
+                    min="0"
                     value={formData.amount}
                     onChange={handleInputChange}
                     placeholder="e.g. 50000"

--- a/collegems-server/src/controllers/scholarship.controller.js
+++ b/collegems-server/src/controllers/scholarship.controller.js
@@ -10,6 +10,10 @@ export const applyScholarship = async (req, res) => {
       return res.status(400).json({ message: "All fields are required" });
     }
 
+    if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+      return res.status(400).json({ message: "Amount must be a positive number" });
+    }
+
     const scholarship = await Scholarship.create({
       studentId: req.user.id,
       scholarshipName,
@@ -85,6 +89,13 @@ export const reviewScholarship = async (req, res) => {
     const scholarship = await Scholarship.findById(id);
     if (!scholarship) {
       return res.status(404).json({ message: "Scholarship application not found" });
+    }
+
+    if (
+      status === "Approved" &&
+      (typeof scholarship.amount !== "number" || !Number.isFinite(scholarship.amount) || scholarship.amount <= 0)
+    ) {
+      return res.status(400).json({ message: "Cannot approve an application with an invalid amount" });
     }
 
     scholarship.status = status;

--- a/collegems-server/src/models/Scholarship.model.js
+++ b/collegems-server/src/models/Scholarship.model.js
@@ -15,6 +15,7 @@ const scholarshipSchema = new mongoose.Schema(
     amount: {
       type: Number,
       required: true,
+      min: 0,
     },
     academicYear: {
       type: String,

--- a/collegems-server/src/tests/scholarshipValidation.test.js
+++ b/collegems-server/src/tests/scholarshipValidation.test.js
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import request from "supertest";
+import app from "../app.js";
+import User from "../models/User.model.js";
+import Scholarship from "../models/Scholarship.model.js";
+import jwt from "jsonwebtoken";
+
+test("Scholarship Amount Validation Tests", async (t) => {
+  let mongoServer;
+  let jwtSecret;
+  let studentToken, studentUser;
+  let hodToken;
+
+  t.before(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+
+    jwtSecret = process.env.JWT_SECRET || "testsecret";
+    process.env.JWT_SECRET = jwtSecret;
+
+    studentUser = await User.create({
+      name: "Scholarship Student",
+      email: "scholarshipstudent@test.com",
+      password: "password123",
+      role: "student",
+      studentId: "S-8001",
+      semester: "3",
+      course: "Computer Science",
+    });
+    studentToken = jwt.sign({ id: studentUser._id, role: studentUser.role }, jwtSecret);
+
+    const hodUser = await User.create({
+      name: "Scholarship HOD",
+      email: "scholarshiphod@test.com",
+      password: "password123",
+      role: "hod",
+      departmentCode: "CS",
+    });
+    hodToken = jwt.sign({ id: hodUser._id, role: hodUser.role }, jwtSecret);
+  });
+
+  t.after(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  await t.test("POST /api/scholarships rejects a negative amount (issue #593 repro)", async () => {
+    const res = await request(app)
+      .post("/api/scholarships")
+      .set("Authorization", `Bearer ${studentToken}`)
+      .send({
+        scholarshipName: "Merit Scholarship",
+        amount: -50000,
+        academicYear: "2026-2027",
+        category: "Merit",
+        reason: "Top of class",
+      });
+
+    assert.strictEqual(res.status, 400);
+    assert.match(res.body.message, /positive number/i);
+
+    const stored = await Scholarship.findOne({ studentId: studentUser._id });
+    assert.strictEqual(stored, null);
+  });
+
+  await t.test("POST /api/scholarships rejects a zero amount", async () => {
+    const res = await request(app)
+      .post("/api/scholarships")
+      .set("Authorization", `Bearer ${studentToken}`)
+      .send({
+        scholarshipName: "Merit Scholarship",
+        amount: 0,
+        academicYear: "2026-2027",
+        category: "Merit",
+        reason: "Top of class",
+      });
+
+    assert.strictEqual(res.status, 400);
+  });
+
+  await t.test("POST /api/scholarships accepts a valid positive amount", async () => {
+    const res = await request(app)
+      .post("/api/scholarships")
+      .set("Authorization", `Bearer ${studentToken}`)
+      .send({
+        scholarshipName: "Merit Scholarship",
+        amount: 50000,
+        academicYear: "2026-2027",
+        category: "Merit",
+        reason: "Top of class",
+      });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.amount, 50000);
+  });
+
+  await t.test("PATCH /:id/review rejects approval of an application with an invalid stored amount", async () => {
+    const bypassed = await Scholarship.collection.insertOne({
+      studentId: studentUser._id,
+      scholarshipName: "Legacy Bad Record",
+      amount: -1000,
+      academicYear: "2026-2027",
+      category: "Merit",
+      reason: "Pre-existing bad data",
+      status: "Pending",
+    });
+
+    const res = await request(app)
+      .patch(`/api/scholarships/${bypassed.insertedId}/review`)
+      .set("Authorization", `Bearer ${hodToken}`)
+      .send({ status: "Approved" });
+
+    assert.strictEqual(res.status, 400);
+    assert.match(res.body.message, /invalid amount/i);
+
+    const stored = await Scholarship.collection.findOne({ _id: bypassed.insertedId });
+    assert.strictEqual(stored.status, "Pending");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #593. `Scholarship.amount` had no sign validation: the schema had no `min`, and the controller's falsy check (`!amount`) only caught `0`/`NaN`, not negative numbers. A student submitting `amount: -50000` passed validation, got stored as a `Pending` application, and could be approved by an HOD with no sanity check — corrupting any downstream reporting/export that sums scholarship amounts.

## Changes
- `Scholarship.model.js`: added `min: 0` to the `amount` field.
- `scholarship.controller.js`:
  - `applyScholarship` now explicitly rejects non-numeric, non-finite, or non-positive amounts (`400`) instead of relying on the falsy check.
  - `reviewScholarship` now sanity-checks the stored `amount` before allowing a transition to `Approved`, so a bad record (e.g. inserted before this fix, or via any other path) can't be approved.
- `Scholarships.tsx` (client): added `min="0"` to the amount input and a client-side check rejecting non-positive amounts before submit, as defense in depth alongside the server-side fix.
- Added `collegems-server/src/tests/scholarshipValidation.test.js` covering the negative-amount repro from the issue, zero-amount rejection, a valid submission, and the HOD-review sanity check against a bad pre-existing record.

## Test plan
- [x] `node --test src/tests/scholarshipValidation.test.js` in `collegems-server` — all 4 tests pass
- [x] `npx tsc --noEmit` in `collegems-client` — no new type errors
- [x] `npx eslint` on the changed client file — no new lint errors vs. base