### PR TITLE
fix(a11y): add htmlFor/id label associations to TeacherProfile form controls (WCAG 2.2 SC 1.3.1)

### DIFF
--- a/collegems-client/src/teacher-components/TeacherProfile.tsx
+++ b/collegems-client/src/teacher-components/TeacherProfile.tsx
@@ -137,10 +137,11 @@ export default function TeacherProfile() {
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="tp-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Full Name <span className="text-red-500">*</span>
                 </label>
                 <input
+                  id="tp-name"
                   type="text"
                   name="name"
                   value={formData.name}
@@ -154,7 +155,7 @@ export default function TeacherProfile() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="tp-teacher-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Teacher ID
                 </label>
                 <div className="relative">
@@ -162,6 +163,7 @@ export default function TeacherProfile() {
                     <Briefcase className="h-4 w-4 text-gray-400" />
                   </div>
                   <input
+                    id="tp-teacher-id"
                     type="text"
                     name="teacherId"
                     value={formData.teacherId}
@@ -184,7 +186,7 @@ export default function TeacherProfile() {
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="tp-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Email Address <span className="text-red-500">*</span>
                 </label>
                 <div className="relative">
@@ -192,6 +194,7 @@ export default function TeacherProfile() {
                     <Mail className="h-4 w-4 text-gray-400" />
                   </div>
                   <input
+                    id="tp-email"
                     type="email"
                     name="email"
                     value={formData.email}
@@ -205,7 +208,7 @@ export default function TeacherProfile() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="tp-phone" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Phone Number
                 </label>
                 <div className="relative">
@@ -213,6 +216,7 @@ export default function TeacherProfile() {
                     <Phone className="h-4 w-4 text-gray-400" />
                   </div>
                   <input
+                    id="tp-phone"
                     type="tel"
                     name="phone"
                     value={formData.phone}
@@ -236,10 +240,11 @@ export default function TeacherProfile() {
             
             <div className="space-y-6">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="tp-department" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Department
                 </label>
                 <input
+                  id="tp-department"
                   type="text"
                   name="department"
                   value={formData.department}
@@ -250,7 +255,7 @@ export default function TeacherProfile() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="tp-office-hours" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Office Hours & Availability
                 </label>
                 <div className="relative">
@@ -258,6 +263,7 @@ export default function TeacherProfile() {
                     <Clock className="h-4 w-4 text-gray-400" />
                   </div>
                   <input
+                    id="tp-office-hours"
                     type="text"
                     name="officeHours"
                     value={formData.officeHours}
@@ -270,7 +276,7 @@ export default function TeacherProfile() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="tp-bio" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Biography / About
                 </label>
                 <div className="relative">
@@ -278,6 +284,7 @@ export default function TeacherProfile() {
                     <FileText className="h-4 w-4 text-gray-400" />
                   </div>
                   <textarea
+                    id="tp-bio"
                     name="bio"
                     rows={4}
                     value={formData.bio}


### PR DESCRIPTION
## Problem

`TeacherProfile.tsx` was recently added but all 7 form controls are 
missing programmatic label associations — a WCAG 2.2 Level A failure 
(SC 1.3.1 — Info and Relationships).

`<label>` elements had no `htmlFor` and their controls had no `id`,
so screen readers cannot announce field names on focus.

## Files Affected

`collegems-client/src/teacher-components/TeacherProfile.tsx`

## Changes Made

| Field | id added |
|---|---|
| Full Name | `tp-name` |
| Teacher ID | `tp-teacher-id` |
| Email Address | `tp-email` |
| Phone Number | `tp-phone` |
| Department | `tp-department` |
| Office Hours | `tp-office-hours` |
| Biography | `tp-bio` |

## Type of Change
- [x] Bug fix (accessibility)

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [ ] Updated documentation

Closes #564
