### PR TITLE
🐛 Fix: Validate confirmation settings before updating (#644)

### DIFF
--- a/collegems-server/controllers/settingsController.js
+++ b/collegems-server/controllers/settingsController.js
@@ -1,12 +1,42 @@
 const Settings = require('../models/Settings');
+const logger = require('../utils/logger');
 
-// Get settings
+const CONFIRMATION_FIELDS = ['delete', 'publish', 'archive', 'update'];
+
+function validateBoolean(value, fieldName) {
+  if (value === undefined || value === null) return true;
+  if (typeof value !== 'boolean') {
+    return {
+      valid: false,
+      error: `${fieldName} must be a boolean value (true or false)`
+    };
+  }
+  return { valid: true };
+}
+
+function validateConfirmationSettings(confirmations) {
+  const errors = [];
+
+  for (const field of CONFIRMATION_FIELDS) {
+    if (confirmations[field] !== undefined) {
+      const validation = validateBoolean(confirmations[field], field);
+      if (!validation.valid) {
+        errors.push(validation.error);
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors
+  };
+}
+
 const getSettings = async (req, res) => {
     try {
         let settings = await Settings.findOne();
         
         if (!settings) {
-            // Create default settings if none exist
             settings = await Settings.create({
                 confirmations: {
                     delete: true,
@@ -19,6 +49,7 @@ const getSettings = async (req, res) => {
         
         res.json({ success: true, data: settings });
     } catch (error) {
+        logger.error('Error getting settings:', error);
         res.status(500).json({
             success: false,
             error: error.message
@@ -26,10 +57,32 @@ const getSettings = async (req, res) => {
     }
 };
 
-// Update settings
 const updateSettings = async (req, res) => {
     try {
         const { confirmations } = req.body;
+        
+        if (!confirmations) {
+            return res.status(400).json({
+                success: false,
+                error: 'Confirmations object is required'
+            });
+        }
+
+        if (typeof confirmations !== 'object' || Array.isArray(confirmations)) {
+            return res.status(400).json({
+                success: false,
+                error: 'Confirmations must be an object'
+            });
+        }
+
+        const validation = validateConfirmationSettings(confirmations);
+        if (!validation.valid) {
+            return res.status(400).json({
+                success: false,
+                error: 'Validation failed',
+                details: validation.errors
+            });
+        }
         
         let settings = await Settings.findOne();
         
@@ -37,20 +90,19 @@ const updateSettings = async (req, res) => {
             settings = new Settings();
         }
         
-        // Update confirmation settings
-        if (confirmations) {
-            settings.confirmations = {
-                delete: confirmations.delete !== undefined ? confirmations.delete : settings.confirmations.delete,
-                publish: confirmations.publish !== undefined ? confirmations.publish : settings.confirmations.publish,
-                archive: confirmations.archive !== undefined ? confirmations.archive : settings.confirmations.archive,
-                update: confirmations.update !== undefined ? confirmations.update : settings.confirmations.update
-            };
-        }
+        settings.confirmations = {
+            delete: confirmations.delete !== undefined ? confirmations.delete : settings.confirmations.delete,
+            publish: confirmations.publish !== undefined ? confirmations.publish : settings.confirmations.publish,
+            archive: confirmations.archive !== undefined ? confirmations.archive : settings.confirmations.archive,
+            update: confirmations.update !== undefined ? confirmations.update : settings.confirmations.update
+        };
         
-        settings.updatedBy = req.user.id;
+        settings.updatedBy = req.user ? req.user.id : null;
         settings.updatedAt = Date.now();
         
         await settings.save();
+
+        logger.info('Settings updated successfully', { updatedBy: req.user?.id });
         
         res.json({
             success: true,
@@ -58,6 +110,7 @@ const updateSettings = async (req, res) => {
             data: settings
         });
     } catch (error) {
+        logger.error('Error updating settings:', error);
         res.status(500).json({
             success: false,
             error: error.message
@@ -65,4 +118,10 @@ const updateSettings = async (req, res) => {
     }
 };
 
-module.exports = { getSettings, updateSettings };
+module.exports = { 
+    getSettings, 
+    updateSettings,
+    validateConfirmationSettings,
+    validateBoolean,
+    CONFIRMATION_FIELDS
+};


### PR DESCRIPTION
## Fixes #644

## Changes Made
- Added `validateBoolean()` function to check boolean values
- Added `validateConfirmationSettings()` function to validate all fields
- Added validation for delete, publish, archive, update fields
- Added 400 Bad Request response for invalid values
- Added clear error messages for each field

## Before
- String values like "false", "true" were accepted
- Number values like 0, 1 were accepted
- Invalid data got stored in database

## After
- Only true/false boolean values are accepted
- Invalid values return 400 error with clear message
- Database stores only valid boolean data


Files Changed
controllers/settingsController.js

Closes #644