### PR TITLE
bullmq-task-queue

### DIFF
--- a/collegems-client/src/hod-components/QueueMonitorDashboard.tsx
+++ b/collegems-client/src/hod-components/QueueMonitorDashboard.tsx
@@ -1,0 +1,363 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Activity,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Loader2,
+  Mail,
+  FileText,
+  BarChart3,
+  RefreshCw,
+  Play,
+} from "lucide-react";
+import api from "../api/axios";
+import { useSocket } from "../context/SocketContext";
+
+interface QueueCounts {
+  waiting?: number;
+  active?: number;
+  completed?: number;
+  failed?: number;
+  delayed?: number;
+}
+
+interface JobRow {
+  id: string;
+  name: string;
+  queueName: string;
+  state: string;
+  progress: number;
+  attemptsMade?: number;
+  failedReason?: string | null;
+  timestamp?: number;
+  data?: {
+    requestedBy?: string;
+    to?: string;
+    title?: string;
+    recipientCount?: number;
+  };
+}
+
+interface QueueSnap {
+  name: string;
+  counts: QueueCounts;
+  jobs: JobRow[];
+}
+
+interface DashboardData {
+  mode: string;
+  redis: { mock: boolean; ready: boolean };
+  queues: QueueSnap[];
+  totals: QueueCounts;
+}
+
+const queueIcon = (name: string) => {
+  if (name.includes("Email")) return <Mail className="w-4 h-4" />;
+  if (name.includes("PDF") || name.includes("Report"))
+    return <FileText className="w-4 h-4" />;
+  return <BarChart3 className="w-4 h-4" />;
+};
+
+const stateTone = (state: string) => {
+  switch (state) {
+    case "completed":
+      return "text-emerald-700 bg-emerald-50 border-emerald-200";
+    case "failed":
+      return "text-red-700 bg-red-50 border-red-200";
+    case "active":
+      return "text-blue-700 bg-blue-50 border-blue-200";
+    default:
+      return "text-slate-700 bg-slate-50 border-slate-200";
+  }
+};
+
+export default function QueueMonitorDashboard() {
+  const { socket, isConnected } = useSocket();
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [liveEvents, setLiveEvents] = useState<
+    Array<{ at: string; text: string }>
+  >([]);
+  const [enqueueBusy, setEnqueueBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await api.get<{ data: DashboardData }>("/queues/dashboard");
+      setData(res.data.data);
+    } catch (err: unknown) {
+      const ax = err as { response?: { data?: { message?: string } } };
+      setError(ax.response?.data?.message || "Failed to load queue dashboard");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const t = setInterval(load, 8000);
+    return () => clearInterval(t);
+  }, [load]);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const onProgress = (payload: {
+      queue?: string;
+      jobId?: string;
+      progress?: number;
+      status?: string;
+    }) => {
+      setLiveEvents((prev) =>
+        [
+          {
+            at: new Date().toLocaleTimeString(),
+            text: `${payload.queue} #${payload.jobId} → ${payload.status} (${payload.progress ?? 0}%)`,
+          },
+          ...prev,
+        ].slice(0, 30)
+      );
+      load();
+    };
+
+    const onDone = (payload: { queue?: string; jobId?: string }) => {
+      setLiveEvents((prev) =>
+        [
+          {
+            at: new Date().toLocaleTimeString(),
+            text: `Completed ${payload.queue} #${payload.jobId}`,
+          },
+          ...prev,
+        ].slice(0, 30)
+      );
+      load();
+    };
+
+    const onFail = (payload: {
+      queue?: string;
+      jobId?: string;
+      error?: string;
+    }) => {
+      setLiveEvents((prev) =>
+        [
+          {
+            at: new Date().toLocaleTimeString(),
+            text: `Failed ${payload.queue} #${payload.jobId}: ${payload.error}`,
+          },
+          ...prev,
+        ].slice(0, 30)
+      );
+      load();
+    };
+
+    socket.on("queue:job_progress", onProgress);
+    socket.on("queue:job_completed", onDone);
+    socket.on("queue:job_failed", onFail);
+    return () => {
+      socket.off("queue:job_progress", onProgress);
+      socket.off("queue:job_completed", onDone);
+      socket.off("queue:job_failed", onFail);
+    };
+  }, [socket, load]);
+
+  const enqueueDemo = async (kind: "email" | "report" | "analytics") => {
+    setEnqueueBusy(true);
+    setMessage(null);
+    try {
+      if (kind === "email") {
+        await api.post("/queues/email", {
+          to: "demo@college.edu",
+          subject: "Queue demo email",
+          text: "This email was enqueued via BullMQ EmailQueue.",
+        });
+      } else if (kind === "report") {
+        await api.post("/queues/reports", {
+          title: "Demo Placement Shortlist",
+          lines: ["Student A — 92%", "Student B — 81%", "Student C — 74%"],
+        });
+      } else {
+        await api.post("/queues/analytics", { studentIds: [] });
+      }
+      setMessage(`${kind} job accepted (202) — watch progress below`);
+      await load();
+    } catch (err: unknown) {
+      const ax = err as { response?: { data?: { message?: string } } };
+      setMessage(ax.response?.data?.message || "Enqueue failed");
+    } finally {
+      setEnqueueBusy(false);
+    }
+  };
+
+  if (loading && !data) {
+    return (
+      <div className="flex justify-center py-16 text-slate-400">
+        <Loader2 className="w-8 h-8 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold text-slate-800 dark:text-white flex items-center gap-2">
+            <Activity className="w-6 h-6 text-indigo-600" />
+            Queue Monitor
+          </h2>
+          <p className="text-sm text-slate-500 mt-1">
+            BullMQ background jobs — Email, Report PDF, Analytics. Mode:{" "}
+            <strong>{data?.mode || "—"}</strong>
+            {data?.redis?.mock ? " (Redis mock / memory fallback)" : ""}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className={`text-xs px-2 py-1 rounded-full border ${
+              isConnected
+                ? "border-emerald-300 bg-emerald-50 text-emerald-800"
+                : "border-amber-300 bg-amber-50 text-amber-800"
+            }`}
+          >
+            Socket {isConnected ? "live" : "offline"}
+          </span>
+          <button
+            type="button"
+            onClick={load}
+            className="inline-flex items-center gap-1 text-sm px-3 py-1.5 rounded-lg border"
+          >
+            <RefreshCw className="w-3.5 h-3.5" /> Refresh
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {error}
+        </div>
+      )}
+      {message && (
+        <div className="text-sm text-slate-700 bg-slate-50 border border-slate-200 rounded-lg px-3 py-2">
+          {message}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {(
+          [
+            ["waiting", Clock, data?.totals.waiting],
+            ["active", Loader2, data?.totals.active],
+            ["completed", CheckCircle2, data?.totals.completed],
+            ["failed", XCircle, data?.totals.failed],
+          ] as const
+        ).map(([label, Icon, value]) => (
+          <div
+            key={label}
+            className="rounded-xl border border-slate-200 bg-white p-4"
+          >
+            <p className="text-xs uppercase text-slate-500 flex items-center gap-1">
+              <Icon className="w-3.5 h-3.5" /> {label}
+            </p>
+            <p className="text-2xl font-bold text-slate-900 mt-1">{value ?? 0}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-4">
+        <h3 className="font-semibold text-slate-800 mb-3">Enqueue demo job</h3>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            disabled={enqueueBusy}
+            onClick={() => enqueueDemo("email")}
+            className="inline-flex items-center gap-1 px-3 py-2 rounded-lg bg-indigo-600 text-white text-sm disabled:opacity-50"
+          >
+            <Play className="w-3.5 h-3.5" /> EmailQueue
+          </button>
+          <button
+            type="button"
+            disabled={enqueueBusy}
+            onClick={() => enqueueDemo("report")}
+            className="inline-flex items-center gap-1 px-3 py-2 rounded-lg bg-slate-800 text-white text-sm disabled:opacity-50"
+          >
+            <Play className="w-3.5 h-3.5" /> ReportPDFQueue
+          </button>
+          <button
+            type="button"
+            disabled={enqueueBusy}
+            onClick={() => enqueueDemo("analytics")}
+            className="inline-flex items-center gap-1 px-3 py-2 rounded-lg border text-sm disabled:opacity-50"
+          >
+            <Play className="w-3.5 h-3.5" /> AnalyticsQueue
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {(data?.queues || []).map((q) => (
+          <div
+            key={q.name}
+            className="rounded-xl border border-slate-200 bg-white overflow-hidden"
+          >
+            <div className="px-4 py-3 border-b border-slate-100 flex items-center justify-between bg-slate-50">
+              <h3 className="font-semibold text-slate-800 flex items-center gap-2 text-sm">
+                {queueIcon(q.name)} {q.name}
+              </h3>
+              <span className="text-[11px] text-slate-500">
+                A{q.counts.active || 0} / W{q.counts.waiting || 0} / F
+                {q.counts.failed || 0}
+              </span>
+            </div>
+            <ul className="max-h-64 overflow-y-auto divide-y divide-slate-100">
+              {(q.jobs || []).slice(0, 12).map((j) => (
+                <li key={`${q.name}-${j.id}`} className="px-3 py-2 text-xs">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-mono truncate">{j.id}</span>
+                    <span
+                      className={`px-1.5 py-0.5 rounded border capitalize ${stateTone(
+                        j.state
+                      )}`}
+                    >
+                      {j.state}
+                    </span>
+                  </div>
+                  <p className="text-slate-500 mt-0.5">
+                    {j.name}
+                    {typeof j.progress === "number" ? ` · ${j.progress}%` : ""}
+                  </p>
+                  {j.failedReason && (
+                    <p className="text-red-600 mt-0.5 truncate">{j.failedReason}</p>
+                  )}
+                </li>
+              ))}
+              {!q.jobs?.length && (
+                <li className="px-3 py-6 text-center text-slate-400 text-xs">
+                  No recent jobs
+                </li>
+              )}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-4">
+        <h3 className="font-semibold text-slate-800 mb-2">Live WebSocket events</h3>
+        {liveEvents.length === 0 ? (
+          <p className="text-sm text-slate-500">
+            Waiting for queue:job_progress events…
+          </p>
+        ) : (
+          <ul className="space-y-1 max-h-40 overflow-y-auto text-xs font-mono">
+            {liveEvents.map((e, i) => (
+              <li key={`${e.at}-${i}`} className="text-slate-700">
+                <span className="text-slate-400">{e.at}</span> {e.text}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/collegems-client/src/pages/HODDashboard.tsx
+++ b/collegems-client/src/pages/HODDashboard.tsx
@@ -40,6 +40,7 @@ import FeedbackManagement from "../hod-components/FeedbackManagement";
 import ExamHalls from "../hod-components/ExamHalls";
 import HallAllocation from "../hod-components/HallAllocation";
 import AuditLogs from "../hod-components/AuditLogs";
+import QueueMonitorDashboard from "../hod-components/QueueMonitorDashboard";
 import BookingManagement from "../hod-components/BookingManagement";
 import ResourceManagement from "../hod-components/ResourceManagement";
 import SemesterManagement from "../hod-components/SemesterManagement";
@@ -84,6 +85,7 @@ type TabType =
   | "exam-halls"
   | "hall-allocation"
   | "audit-logs"
+  | "queue-monitor"
   | "manage-bookings"
   | "manage-resources"
   | "risk-dashboard"
@@ -171,6 +173,7 @@ export default function HODDashboard() {
     { id: "exam-halls" as TabType, label: "Exam Halls", icon: Building2 },
     { id: "hall-allocation" as TabType, label: "Hall Allocation", icon: Users },
     { id: "audit-logs" as TabType, label: "Audit Logs", icon: FileText },
+    { id: "queue-monitor" as TabType, label: "Job Queues", icon: Activity },
     { id: "system-logs" as TabType, label: "System Traces", icon: FileText },
     { id: "system-health" as TabType, label: "System Health", icon: Activity },
     { id: "manage-bookings" as TabType, label: "Manage Bookings", icon: Calendar },
@@ -577,6 +580,7 @@ export default function HODDashboard() {
         {activeTab === "exam-halls" && <ExamHalls />}
         {activeTab === "hall-allocation" && <HallAllocation />}
         {activeTab === "audit-logs" && <AuditLogs />}
+        {activeTab === "queue-monitor" && <QueueMonitorDashboard />}
         {activeTab === "system-health" && <SystemHealthDashboard />}
         {activeTab === "manage-bookings" && <BookingManagement />}
         { activeTab === "manage-resources" && <ResourceManagement /> }

--- a/collegems-server/.env.example
+++ b/collegems-server/.env.example
@@ -145,6 +145,8 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=0
+# Set true to skip Redis and use in-memory BullMQ fallback (CI / local demos)
+MOCK_REDIS=false
 
 # ============================================
 # FILE UPLOAD CONFIGURATION

--- a/collegems-server/package-lock.json
+++ b/collegems-server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "amqplib": "^2.0.1",
         "bcryptjs": "^3.0.3",
+        "bullmq": "^6.0.3",
         "compression": "^1.8.1",
         "concurrently": "^10.0.3",
         "cookie-parser": "^1.4.7",
@@ -22,6 +23,7 @@
         "express-validator": "^7.3.2",
         "helmet": "^8.2.0",
         "http-proxy-middleware": "^4.1.1",
+        "ioredis": "^6.0.0",
         "jsonwebtoken": "^9.0.3",
         "mammoth": "^1.12.0",
         "mongodb": "^7.1.0",
@@ -68,6 +70,12 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
+      "integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==",
+      "license": "MIT"
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.5.tgz",
@@ -76,6 +84,84 @@
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -677,6 +763,42 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/bullmq": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-6.0.3.tgz",
+      "integrity": "sha512-ri/ugcNf4G/knwnMd2LVuwIdyzI9A2a2CipYvvfG6H4I1X23DhNrDtd8yuj46dqeE8kdoUSPlTJ9rEtfs4W/cg==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "5.6.1",
+        "msgpackr": "2.0.5",
+        "node-abort-controller": "3.1.1",
+        "semver": "7.8.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=14.17.0"
+      },
+      "peerDependencies": {
+        "bullmq-otel": ">=2.0.0",
+        "ioredis": ">=5.0.0",
+        "pg": ">=8.0.0",
+        "redis": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "bullmq-otel": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1237,6 +1359,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.6.1.tgz",
+      "integrity": "sha512-QBm4o1PwZiuY7KFbVvW7FLC8bozy7YWzv+Fz6KRS7sQghzcbDZCGxr/Bc5b6TQreAoSwuWVP491dIcK0THCX6A==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
@@ -1279,6 +1413,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1286,6 +1429,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dezalgo": {
@@ -2093,6 +2246,36 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-6.0.0.tgz",
+      "integrity": "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "2.0.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.2.0.tgz",
@@ -2449,6 +2632,15 @@
         "duck": "^0.1.12",
         "option": "~0.2.1",
         "underscore": "^1.13.1"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -2843,6 +3035,37 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
+      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
     "node_modules/multer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
@@ -2964,6 +3187,12 @@
         "node": ">=12.22.0"
       }
     },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "license": "MIT"
+    },
     "node_modules/node-cache": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
@@ -2990,6 +3219,21 @@
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
       "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/nodemailer": {
       "version": "8.0.11",
@@ -3527,6 +3771,15 @@
         "node": ">= 18.19.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3609,9 +3862,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3901,6 +4154,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/collegems-server/package.json
+++ b/collegems-server/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "amqplib": "^2.0.1",
     "bcryptjs": "^3.0.3",
+    "bullmq": "^6.0.3",
     "compression": "^1.8.1",
     "concurrently": "^10.0.3",
     "cookie-parser": "^1.4.7",
@@ -29,6 +30,7 @@
     "express-validator": "^7.3.2",
     "helmet": "^8.2.0",
     "http-proxy-middleware": "^4.1.1",
+    "ioredis": "^6.0.0",
     "jsonwebtoken": "^9.0.3",
     "mammoth": "^1.12.0",
     "mongodb": "^7.1.0",

--- a/collegems-server/src/bootstrap/index.js
+++ b/collegems-server/src/bootstrap/index.js
@@ -152,6 +152,17 @@ io.on("connection", (socket) => {
 
   initializeStudyGroupSockets(io);
 
+  // BullMQ / Redis background workers (#705)
+  import("../config/redis.config.js")
+    .then((redis) => redis.getRedisConnection())
+    .then(() => import("../queues/queue.registry.js"))
+    .then((q) => q.initQueues())
+    .then(() => import("../workers/bullWorkers.js"))
+    .then((w) => w.startBullWorkers(io))
+    .catch((err) => {
+      console.warn("Queue bootstrap warning:", err.message);
+    });
+
   freePort();
 
   // ✅ RETURN BOTH THE EXPRESS APP AND HTTP SERVER TO server.js

--- a/collegems-server/src/config/redis.config.js
+++ b/collegems-server/src/config/redis.config.js
@@ -1,0 +1,91 @@
+import IORedis from "ioredis";
+import log from "../utils/logger.js";
+
+const MOCK_REDIS =
+  process.env.MOCK_REDIS === "true" ||
+  process.env.REDIS_DISABLED === "true";
+
+let connection = null;
+let connectionReady = false;
+let connectionError = null;
+
+/**
+ * Shared Redis connection options for BullMQ.
+ * BullMQ requires maxRetriesPerRequest: null on the connection.
+ */
+export function getRedisOptions() {
+  return {
+    host: process.env.REDIS_HOST || "localhost",
+    port: Number(process.env.REDIS_PORT) || 6379,
+    password: process.env.REDIS_PASSWORD || undefined,
+    db: Number(process.env.REDIS_DB) || 0,
+    maxRetriesPerRequest: null,
+    enableReadyCheck: true,
+    lazyConnect: true,
+  };
+}
+
+export function isRedisMockMode() {
+  return MOCK_REDIS || Boolean(connectionError);
+}
+
+export function isRedisReady() {
+  return connectionReady && !MOCK_REDIS;
+}
+
+/**
+ * Create (or return) a shared ioredis client. Never throws — fails soft for OSS demos.
+ */
+export async function getRedisConnection() {
+  if (MOCK_REDIS) {
+    connectionError = "MOCK_REDIS=true";
+    return null;
+  }
+
+  if (connection && connectionReady) return connection;
+
+  try {
+    connection = new IORedis(getRedisOptions());
+    connection.on("error", (err) => {
+      connectionError = err.message;
+      connectionReady = false;
+      log.warn?.(`Redis error: ${err.message}`) ||
+        console.warn(`Redis error: ${err.message}`);
+    });
+    connection.on("ready", () => {
+      connectionReady = true;
+      connectionError = null;
+      console.log("Redis connected for BullMQ queues");
+    });
+    await connection.connect();
+    connectionReady = true;
+    return connection;
+  } catch (err) {
+    connectionError = err.message;
+    connectionReady = false;
+    console.warn(
+      `Redis unavailable (${err.message}) — BullMQ will use in-memory fallback`
+    );
+    return null;
+  }
+}
+
+export async function closeRedisConnection() {
+  if (connection) {
+    try {
+      await connection.quit();
+    } catch {
+      connection.disconnect();
+    }
+    connection = null;
+    connectionReady = false;
+  }
+}
+
+export default {
+  getRedisConnection,
+  getRedisOptions,
+  closeRedisConnection,
+  isRedisMockMode,
+  isRedisReady,
+};

--- a/collegems-server/src/controllers/queue.controller.js
+++ b/collegems-server/src/controllers/queue.controller.js
@@ -1,0 +1,78 @@
+import {
+  enqueueBulkEmail,
+  enqueueSingleEmail,
+  enqueueReportPdf,
+  enqueueAnalytics,
+  getQueueDashboard,
+  getJobStatus,
+} from "../services/queue.service.js";
+import { QUEUE_NAMES } from "../queues/queue.registry.js";
+
+export const getDashboard = async (req, res) => {
+  try {
+    const data = await getQueueDashboard();
+    res.json({ success: true, data });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const getJob = async (req, res) => {
+  try {
+    const job = await getJobStatus(req.params.queueName, req.params.jobId);
+    if (!job) {
+      return res.status(404).json({ success: false, message: "Job not found" });
+    }
+    res.json({ success: true, data: job });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const enqueueEmailJob = async (req, res) => {
+  try {
+    const { to, subject, text, html, recipients } = req.body;
+    let result;
+    if (Array.isArray(recipients) && recipients.length) {
+      result = await enqueueBulkEmail(recipients, req.user.id);
+    } else {
+      if (!to || !subject) {
+        return res.status(400).json({ message: "to and subject are required" });
+      }
+      result = await enqueueSingleEmail(
+        { to, subject, text, html },
+        req.user.id
+      );
+    }
+    res.status(202).json({ success: true, data: result });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const enqueueReportJob = async (req, res) => {
+  try {
+    const { title, lines, fileName } = req.body;
+    const result = await enqueueReportPdf(
+      { title, lines, fileName },
+      req.user.id
+    );
+    res.status(202).json({ success: true, data: result });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const enqueueAnalyticsJob = async (req, res) => {
+  try {
+    const { studentIds } = req.body;
+    const result = await enqueueAnalytics({ studentIds }, req.user.id);
+    res.status(202).json({ success: true, data: result });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+export const listQueueNames = (_req, res) => {
+  res.json({ success: true, data: Object.values(QUEUE_NAMES) });
+};

--- a/collegems-server/src/queues/jobProgress.js
+++ b/collegems-server/src/queues/jobProgress.js
@@ -1,0 +1,21 @@
+/**
+ * Emit real-time job progress to Socket.io rooms (requester + hod).
+ */
+export function emitJobProgress(io, payload) {
+  if (!io) return;
+  const event = "queue:job_progress";
+  io.to("hod").emit(event, payload);
+  io.to("admin").emit(event, payload);
+  if (payload.requestedBy) {
+    io.to(`user_${payload.requestedBy}`).emit(event, payload);
+  }
+}
+
+export function emitJobEvent(io, event, payload) {
+  if (!io) return;
+  io.to("hod").emit(event, payload);
+  io.to("admin").emit(event, payload);
+  if (payload.requestedBy) {
+    io.to(`user_${payload.requestedBy}`).emit(event, payload);
+  }
+}

--- a/collegems-server/src/queues/queue.registry.js
+++ b/collegems-server/src/queues/queue.registry.js
@@ -1,0 +1,178 @@
+import { Queue } from "bullmq";
+import { getRedisOptions, isRedisMockMode } from "../config/redis.config.js";
+
+export const QUEUE_NAMES = {
+  EMAIL: "EmailQueue",
+  REPORT_PDF: "ReportPDFQueue",
+  ANALYTICS: "AnalyticsQueue",
+};
+
+/** In-memory job store when Redis is down (demo / CI). */
+const memoryJobs = new Map(); // id -> job record
+const memoryByQueue = {
+  [QUEUE_NAMES.EMAIL]: [],
+  [QUEUE_NAMES.REPORT_PDF]: [],
+  [QUEUE_NAMES.ANALYTICS]: [],
+};
+
+let emailQueue = null;
+let reportPdfQueue = null;
+let analyticsQueue = null;
+let bullEnabled = false;
+
+function makeMemoryJob(queueName, name, data, opts = {}) {
+  const id = `mem_${queueName}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const job = {
+    id,
+    name,
+    queueName,
+    data,
+    opts,
+    progress: 0,
+    state: "waiting",
+    attemptsMade: 0,
+    failedReason: null,
+    returnvalue: null,
+    timestamp: Date.now(),
+    finishedOn: null,
+    processedOn: null,
+  };
+  memoryJobs.set(id, job);
+  memoryByQueue[queueName].unshift(id);
+  if (memoryByQueue[queueName].length > 200) {
+    const old = memoryByQueue[queueName].pop();
+    memoryJobs.delete(old);
+  }
+  return job;
+}
+
+export function getMemoryJob(id) {
+  return memoryJobs.get(id) || null;
+}
+
+export function updateMemoryJob(id, patch) {
+  const job = memoryJobs.get(id);
+  if (!job) return null;
+  Object.assign(job, patch);
+  return job;
+}
+
+export function listMemoryJobs(queueName, limit = 50) {
+  const ids = memoryByQueue[queueName] || [];
+  return ids.slice(0, limit).map((id) => memoryJobs.get(id)).filter(Boolean);
+}
+
+export function memoryQueueCounts(queueName) {
+  const jobs = listMemoryJobs(queueName, 500);
+  return {
+    waiting: jobs.filter((j) => j.state === "waiting").length,
+    active: jobs.filter((j) => j.state === "active").length,
+    completed: jobs.filter((j) => j.state === "completed").length,
+    failed: jobs.filter((j) => j.state === "failed").length,
+    delayed: jobs.filter((j) => j.state === "delayed").length,
+  };
+}
+
+/**
+ * Initialize BullMQ queues (call once after Redis connect attempt).
+ */
+export async function initQueues() {
+  if (isRedisMockMode()) {
+    bullEnabled = false;
+    console.warn("BullMQ queues: in-memory fallback mode");
+    return { bullEnabled: false };
+  }
+
+  try {
+    const connection = getRedisOptions();
+    const defaults = {
+      connection,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: "exponential", delay: 2000 },
+        removeOnComplete: { count: 100 },
+        removeOnFail: { count: 200 },
+      },
+    };
+
+    emailQueue = new Queue(QUEUE_NAMES.EMAIL, defaults);
+    reportPdfQueue = new Queue(QUEUE_NAMES.REPORT_PDF, defaults);
+    analyticsQueue = new Queue(QUEUE_NAMES.ANALYTICS, defaults);
+    bullEnabled = true;
+    console.log("BullMQ queues ready:", Object.values(QUEUE_NAMES).join(", "));
+    return { bullEnabled: true };
+  } catch (err) {
+    bullEnabled = false;
+    console.warn("BullMQ init failed, using memory fallback:", err.message);
+    return { bullEnabled: false };
+  }
+}
+
+export function isBullEnabled() {
+  return bullEnabled;
+}
+
+export function getEmailQueue() {
+  return emailQueue;
+}
+export function getReportPdfQueue() {
+  return reportPdfQueue;
+}
+export function getAnalyticsQueue() {
+  return analyticsQueue;
+}
+
+/**
+ * Enqueue a job — BullMQ when available, else in-memory.
+ */
+export async function enqueueJob(queueName, jobName, data, opts = {}) {
+  if (bullEnabled) {
+    const q =
+      queueName === QUEUE_NAMES.EMAIL
+        ? emailQueue
+        : queueName === QUEUE_NAMES.REPORT_PDF
+          ? reportPdfQueue
+          : analyticsQueue;
+    if (!q) throw new Error(`Queue ${queueName} not initialized`);
+    const job = await q.add(jobName, data, opts);
+    return {
+      id: String(job.id),
+      name: jobName,
+      queueName,
+      mode: "bullmq",
+    };
+  }
+
+  const job = makeMemoryJob(queueName, jobName, data, opts);
+  // Process asynchronously via memory worker hook
+  setImmediate(() => {
+    import("../workers/memoryWorkerBridge.js")
+      .then((m) => m.processMemoryJob(job))
+      .catch((err) => {
+        updateMemoryJob(job.id, {
+          state: "failed",
+          failedReason: err.message,
+          finishedOn: Date.now(),
+        });
+      });
+  });
+
+  return {
+    id: job.id,
+    name: jobName,
+    queueName,
+    mode: "memory",
+  };
+}
+
+export async function closeQueues() {
+  await Promise.allSettled([
+    emailQueue?.close(),
+    reportPdfQueue?.close(),
+    analyticsQueue?.close(),
+  ]);
+  emailQueue = null;
+  reportPdfQueue = null;
+  analyticsQueue = null;
+  bullEnabled = false;
+}

--- a/collegems-server/src/routes/index.js
+++ b/collegems-server/src/routes/index.js
@@ -89,6 +89,7 @@ import ownershipRoutes from "./ownership.routes.js";
 import savedFilterRoutes from "./savedFilter.routes.js";
 import abandonmentRoutes from "./abandonment.routes.js";
 import temporaryLinkRoutes from "./temporaryLink.routes.js";
+import queueRoutes from "./queue.routes.js";
 
 // ========================================
 // MIDDLEWARES
@@ -191,6 +192,7 @@ authenticatedRouter.use("/workflows", workflowRoutes);
 authenticatedRouter.use("/dependencies", dependencyRoutes);
 authenticatedRouter.use("/data-locks", dataLockRoutes);
 authenticatedRouter.use("/snapshots", snapshotRoutes);
+authenticatedRouter.use("/queues", queueRoutes);
 authenticatedRouter.use("/sequences", sequenceRoutes);
 authenticatedRouter.use("/ownership", ownershipRoutes);
 authenticatedRouter.use("/saved-filters", savedFilterRoutes);

--- a/collegems-server/src/routes/queue.routes.js
+++ b/collegems-server/src/routes/queue.routes.js
@@ -1,0 +1,25 @@
+import express from "express";
+import { protect, restrictTo } from "../middlewares/auth.middleware.js";
+import {
+  getDashboard,
+  getJob,
+  enqueueEmailJob,
+  enqueueReportJob,
+  enqueueAnalyticsJob,
+  listQueueNames,
+} from "../controllers/queue.controller.js";
+
+const router = express.Router();
+
+router.use(protect);
+router.use(restrictTo("admin", "hod"));
+
+router.get("/names", listQueueNames);
+router.get("/dashboard", getDashboard);
+router.get("/:queueName/jobs/:jobId", getJob);
+
+router.post("/email", enqueueEmailJob);
+router.post("/reports", enqueueReportJob);
+router.post("/analytics", enqueueAnalyticsJob);
+
+export default router;

--- a/collegems-server/src/services/queue.service.js
+++ b/collegems-server/src/services/queue.service.js
@@ -1,0 +1,170 @@
+import {
+  QUEUE_NAMES,
+  enqueueJob,
+  isBullEnabled,
+  getEmailQueue,
+  getReportPdfQueue,
+  getAnalyticsQueue,
+  listMemoryJobs,
+  memoryQueueCounts,
+  getMemoryJob,
+} from "../queues/queue.registry.js";
+import { isRedisMockMode, isRedisReady } from "../config/redis.config.js";
+
+export async function enqueueBulkEmail(recipients, requestedBy) {
+  return enqueueJob(QUEUE_NAMES.EMAIL, "bulk-email", {
+    recipients,
+    requestedBy,
+  });
+}
+
+export async function enqueueSingleEmail({ to, subject, text, html }, requestedBy) {
+  return enqueueJob(QUEUE_NAMES.EMAIL, "single-email", {
+    to,
+    subject,
+    text,
+    html,
+    requestedBy,
+  });
+}
+
+export async function enqueueReportPdf(payload, requestedBy) {
+  return enqueueJob(QUEUE_NAMES.REPORT_PDF, "generate-report-pdf", {
+    ...payload,
+    requestedBy,
+  });
+}
+
+export async function enqueueAnalytics(payload, requestedBy) {
+  return enqueueJob(QUEUE_NAMES.ANALYTICS, "batch-analytics", {
+    ...payload,
+    requestedBy,
+  });
+}
+
+function serializeBullJob(job, state) {
+  return {
+    id: String(job.id),
+    name: job.name,
+    queueName: job.queueName,
+    state,
+    progress: typeof job.progress === "number" ? job.progress : job.progress || 0,
+    attemptsMade: job.attemptsMade,
+    failedReason: job.failedReason || null,
+    timestamp: job.timestamp,
+    finishedOn: job.finishedOn,
+    processedOn: job.processedOn,
+    data: {
+      requestedBy: job.data?.requestedBy,
+      to: job.data?.to,
+      title: job.data?.title,
+      recipientCount: job.data?.recipients?.length,
+    },
+  };
+}
+
+async function bullQueueSnapshot(queue, queueName) {
+  if (!queue) {
+    return {
+      name: queueName,
+      counts: memoryQueueCounts(queueName),
+      jobs: listMemoryJobs(queueName).map((j) => ({
+        id: j.id,
+        name: j.name,
+        queueName: j.queueName,
+        state: j.state,
+        progress: j.progress,
+        attemptsMade: j.attemptsMade,
+        failedReason: j.failedReason,
+        timestamp: j.timestamp,
+        finishedOn: j.finishedOn,
+        processedOn: j.processedOn,
+        data: {
+          requestedBy: j.data?.requestedBy,
+          to: j.data?.to,
+          title: j.data?.title,
+          recipientCount: j.data?.recipients?.length,
+        },
+      })),
+    };
+  }
+
+  const counts = await queue.getJobCounts(
+    "waiting",
+    "active",
+    "completed",
+    "failed",
+    "delayed"
+  );
+  const [waiting, active, completed, failed] = await Promise.all([
+    queue.getJobs(["waiting"], 0, 20),
+    queue.getJobs(["active"], 0, 20),
+    queue.getJobs(["completed"], 0, 20),
+    queue.getJobs(["failed"], 0, 20),
+  ]);
+
+  const jobs = [
+    ...active.map((j) => serializeBullJob(j, "active")),
+    ...waiting.map((j) => serializeBullJob(j, "waiting")),
+    ...failed.map((j) => serializeBullJob(j, "failed")),
+    ...completed.map((j) => serializeBullJob(j, "completed")),
+  ];
+
+  return { name: queueName, counts, jobs };
+}
+
+export async function getQueueDashboard() {
+  const mode = isBullEnabled() ? "bullmq" : "memory";
+  const queues = await Promise.all([
+    bullQueueSnapshot(getEmailQueue(), QUEUE_NAMES.EMAIL),
+    bullQueueSnapshot(getReportPdfQueue(), QUEUE_NAMES.REPORT_PDF),
+    bullQueueSnapshot(getAnalyticsQueue(), QUEUE_NAMES.ANALYTICS),
+  ]);
+
+  return {
+    mode,
+    redis: {
+      mock: isRedisMockMode(),
+      ready: isRedisReady(),
+    },
+    queues,
+    totals: queues.reduce(
+      (acc, q) => {
+        acc.waiting += q.counts.waiting || 0;
+        acc.active += q.counts.active || 0;
+        acc.completed += q.counts.completed || 0;
+        acc.failed += q.counts.failed || 0;
+        return acc;
+      },
+      { waiting: 0, active: 0, completed: 0, failed: 0 }
+    ),
+  };
+}
+
+export async function getJobStatus(queueName, jobId) {
+  if (!isBullEnabled()) {
+    const job = getMemoryJob(jobId);
+    if (!job) return null;
+    return {
+      id: job.id,
+      name: job.name,
+      queueName: job.queueName,
+      state: job.state,
+      progress: job.progress,
+      failedReason: job.failedReason,
+      returnvalue: job.returnvalue,
+    };
+  }
+
+  const q =
+    queueName === QUEUE_NAMES.EMAIL
+      ? getEmailQueue()
+      : queueName === QUEUE_NAMES.REPORT_PDF
+        ? getReportPdfQueue()
+        : getAnalyticsQueue();
+  if (!q) return null;
+  const job = await q.getJob(jobId);
+  if (!job) return null;
+  const state = await job.getState();
+  return serializeBullJob(job, state);
+}

--- a/collegems-server/src/tests/queue.registry.test.js
+++ b/collegems-server/src/tests/queue.registry.test.js
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  QUEUE_NAMES,
+  enqueueJob,
+  listMemoryJobs,
+  memoryQueueCounts,
+  initQueues,
+} from "../queues/queue.registry.js";
+
+describe("queue.registry memory fallback", () => {
+  it("exposes canonical queue names", () => {
+    assert.equal(QUEUE_NAMES.EMAIL, "EmailQueue");
+    assert.equal(QUEUE_NAMES.REPORT_PDF, "ReportPDFQueue");
+    assert.equal(QUEUE_NAMES.ANALYTICS, "AnalyticsQueue");
+  });
+
+  it("enqueues into memory when Bull is not enabled", async () => {
+    process.env.MOCK_REDIS = "true";
+    await initQueues();
+    const job = await enqueueJob(QUEUE_NAMES.EMAIL, "single-email", {
+      to: "a@b.com",
+      subject: "t",
+      text: "hello",
+    });
+    assert.ok(job.id);
+    assert.equal(job.mode, "memory");
+    const listed = listMemoryJobs(QUEUE_NAMES.EMAIL, 5);
+    assert.ok(listed.some((j) => j.id === job.id));
+    const counts = memoryQueueCounts(QUEUE_NAMES.EMAIL);
+    assert.ok(counts.waiting + counts.active + counts.completed + counts.failed >= 1);
+  });
+});

--- a/collegems-server/src/utils/processErrorHandlers.js
+++ b/collegems-server/src/utils/processErrorHandlers.js
@@ -164,12 +164,13 @@ async function closeDatabaseConnections() {
 // Close Redis connections
 async function closeRedisConnections() {
     try {
-        // If using Redis
-        // const redisClient = require('../config/redis');
-        // await redisClient.quit();
-        // logger.info('Redis connections closed');
-        
-        logger.info('Redis connections closed');
+        const { closeRedisConnection } = await import('../config/redis.config.js');
+        await closeRedisConnection();
+        const { closeQueues } = await import('../queues/queue.registry.js');
+        await closeQueues();
+        const { stopBullWorkers } = await import('../workers/bullWorkers.js');
+        await stopBullWorkers();
+        logger.info('Redis / BullMQ connections closed');
     } catch (error) {
         logger.error('Failed to close Redis connections', error);
         throw error;

--- a/collegems-server/src/workers/analyticsWorker.js
+++ b/collegems-server/src/workers/analyticsWorker.js
@@ -1,0 +1,78 @@
+import { emitJobProgress, emitJobEvent } from "../queues/jobProgress.js";
+
+/**
+ * Heavy analytics batch — wraps existing analytics service when available.
+ * data: { studentIds?: string[], requestedBy }
+ */
+export async function processAnalyticsJob(job, io) {
+  const data = job.data || {};
+  const requestedBy = data.requestedBy;
+  const jobId = String(job.id);
+
+  const emit = (progress, status, extra = {}) => {
+    emitJobProgress(io, {
+      queue: "AnalyticsQueue",
+      jobId,
+      name: job.name,
+      progress,
+      status,
+      requestedBy,
+      ...extra,
+    });
+  };
+
+  emit(5, "active");
+
+  let processed = 0;
+  try {
+    const { batchGenerateAnalytics, generateAnalyticsForStudent } =
+      await import("../services/analytics.service.js");
+
+    if (Array.isArray(data.studentIds) && data.studentIds.length) {
+      const total = data.studentIds.length;
+      for (let i = 0; i < total; i++) {
+        try {
+          await generateAnalyticsForStudent(data.studentIds[i]);
+          processed += 1;
+        } catch {
+          /* continue batch */
+        }
+        const progress = Math.round(((i + 1) / total) * 100);
+        if (typeof job.updateProgress === "function") {
+          await job.updateProgress(progress);
+        }
+        emit(progress, "active", { processed, total });
+      }
+      emit(100, "completed", { processed, total });
+      emitJobEvent(io, "queue:job_completed", {
+        queue: "AnalyticsQueue",
+        jobId,
+        requestedBy,
+        result: { processed, total },
+      });
+      return { processed, total };
+    }
+
+    // Full batch — fire existing helper then mark complete
+    emit(30, "active");
+    if (typeof batchGenerateAnalytics === "function") {
+      // Don't await forever if it self-schedules; race with timeout
+      await Promise.race([
+        batchGenerateAnalytics(),
+        new Promise((r) => setTimeout(r, 2000)),
+      ]);
+    }
+    if (typeof job.updateProgress === "function") await job.updateProgress(100);
+    emit(100, "completed", { processed: "batch" });
+    emitJobEvent(io, "queue:job_completed", {
+      queue: "AnalyticsQueue",
+      jobId,
+      requestedBy,
+      result: { mode: "batch" },
+    });
+    return { mode: "batch" };
+  } catch (err) {
+    emit(100, "failed", { error: err.message });
+    throw err;
+  }
+}

--- a/collegems-server/src/workers/bullWorkers.js
+++ b/collegems-server/src/workers/bullWorkers.js
@@ -1,0 +1,65 @@
+import { Worker } from "bullmq";
+import { getRedisOptions, isRedisMockMode } from "../config/redis.config.js";
+import { QUEUE_NAMES, isBullEnabled } from "../queues/queue.registry.js";
+import { processEmailJob } from "./emailWorker.js";
+import { processReportPdfJob } from "./reportWorker.js";
+import { processAnalyticsJob } from "./analyticsWorker.js";
+import { emitJobEvent } from "../queues/jobProgress.js";
+import { setWorkerIo, getWorkerIo } from "./workerIo.js";
+
+let workers = [];
+
+function attachWorkerEvents(worker, queueLabel) {
+  worker.on("failed", (job, err) => {
+    emitJobEvent(getWorkerIo(), "queue:job_failed", {
+      queue: queueLabel,
+      jobId: job?.id,
+      requestedBy: job?.data?.requestedBy,
+      error: err.message,
+    });
+  });
+  worker.on("error", (err) => {
+    console.warn(`[${queueLabel}] worker error:`, err.message);
+  });
+}
+
+export function startBullWorkers(io) {
+  setWorkerIo(io);
+
+  if (isRedisMockMode() || !isBullEnabled()) {
+    console.warn("BullMQ workers skipped (Redis mock / queues not enabled)");
+    return [];
+  }
+
+  const connection = getRedisOptions();
+  const common = { connection, concurrency: 2 };
+
+  const email = new Worker(
+    QUEUE_NAMES.EMAIL,
+    async (job) => processEmailJob(job, getWorkerIo()),
+    common
+  );
+  const report = new Worker(
+    QUEUE_NAMES.REPORT_PDF,
+    async (job) => processReportPdfJob(job, getWorkerIo()),
+    common
+  );
+  const analytics = new Worker(
+    QUEUE_NAMES.ANALYTICS,
+    async (job) => processAnalyticsJob(job, getWorkerIo()),
+    { ...common, concurrency: 1 }
+  );
+
+  attachWorkerEvents(email, QUEUE_NAMES.EMAIL);
+  attachWorkerEvents(report, QUEUE_NAMES.REPORT_PDF);
+  attachWorkerEvents(analytics, QUEUE_NAMES.ANALYTICS);
+
+  workers = [email, report, analytics];
+  console.log("BullMQ workers started for Email / ReportPDF / Analytics");
+  return workers;
+}
+
+export async function stopBullWorkers() {
+  await Promise.allSettled(workers.map((w) => w.close()));
+  workers = [];
+}

--- a/collegems-server/src/workers/emailWorker.js
+++ b/collegems-server/src/workers/emailWorker.js
@@ -1,0 +1,71 @@
+import { sendEmail } from "../utils/email.js";
+import { emitJobProgress, emitJobEvent } from "../queues/jobProgress.js";
+
+/**
+ * Process email jobs: single or bulk.
+ * data: { to, subject, text, html } | { recipients: [{to,subject,text,html}], requestedBy }
+ */
+export async function processEmailJob(job, io) {
+  const data = job.data || {};
+  const requestedBy = data.requestedBy;
+  const jobId = String(job.id);
+
+  const emit = (progress, status, extra = {}) => {
+    emitJobProgress(io, {
+      queue: "EmailQueue",
+      jobId,
+      name: job.name,
+      progress,
+      status,
+      requestedBy,
+      ...extra,
+    });
+  };
+
+  emit(5, "active");
+
+  if (Array.isArray(data.recipients) && data.recipients.length) {
+    const total = data.recipients.length;
+    let sent = 0;
+    let failed = 0;
+    for (let i = 0; i < total; i++) {
+      const r = data.recipients[i];
+      const ok = await sendEmail(r.to, r.subject, r.text || "", r.html || "");
+      if (ok) sent += 1;
+      else failed += 1;
+      const progress = Math.round(((i + 1) / total) * 100);
+      if (typeof job.updateProgress === "function") {
+        await job.updateProgress(progress);
+      }
+      emit(progress, "active", { sent, failed, total });
+    }
+    emit(100, "completed", { sent, failed, total });
+    emitJobEvent(io, "queue:job_completed", {
+      queue: "EmailQueue",
+      jobId,
+      requestedBy,
+      result: { sent, failed, total },
+    });
+    return { sent, failed, total };
+  }
+
+  const ok = await sendEmail(
+    data.to,
+    data.subject,
+    data.text || "",
+    data.html || ""
+  );
+  if (typeof job.updateProgress === "function") await job.updateProgress(100);
+  if (!ok) {
+    emit(100, "failed", { error: "sendEmail returned false" });
+    throw new Error("Failed to send email");
+  }
+  emit(100, "completed");
+  emitJobEvent(io, "queue:job_completed", {
+    queue: "EmailQueue",
+    jobId,
+    requestedBy,
+    result: { sent: 1 },
+  });
+  return { sent: 1 };
+}

--- a/collegems-server/src/workers/memoryWorkerBridge.js
+++ b/collegems-server/src/workers/memoryWorkerBridge.js
@@ -1,0 +1,51 @@
+import {
+  updateMemoryJob,
+  QUEUE_NAMES,
+} from "../queues/queue.registry.js";
+import { processEmailJob } from "./emailWorker.js";
+import { processReportPdfJob } from "./reportWorker.js";
+import { processAnalyticsJob } from "./analyticsWorker.js";
+import { getWorkerIo } from "./workerIo.js";
+
+/**
+ * Process in-memory fallback jobs when Redis is unavailable.
+ */
+export async function processMemoryJob(job) {
+  const io = getWorkerIo();
+  updateMemoryJob(job.id, { state: "active", processedOn: Date.now(), progress: 1 });
+
+  const fakeBullJob = {
+    id: job.id,
+    name: job.name,
+    data: job.data,
+    updateProgress: async (p) => {
+      updateMemoryJob(job.id, { progress: p });
+    },
+  };
+
+  try {
+    let result;
+    if (job.queueName === QUEUE_NAMES.EMAIL) {
+      result = await processEmailJob(fakeBullJob, io);
+    } else if (job.queueName === QUEUE_NAMES.REPORT_PDF) {
+      result = await processReportPdfJob(fakeBullJob, io);
+    } else if (job.queueName === QUEUE_NAMES.ANALYTICS) {
+      result = await processAnalyticsJob(fakeBullJob, io);
+    } else {
+      throw new Error(`Unknown queue ${job.queueName}`);
+    }
+    updateMemoryJob(job.id, {
+      state: "completed",
+      progress: 100,
+      returnvalue: result,
+      finishedOn: Date.now(),
+    });
+  } catch (err) {
+    updateMemoryJob(job.id, {
+      state: "failed",
+      failedReason: err.message,
+      finishedOn: Date.now(),
+    });
+    throw err;
+  }
+}

--- a/collegems-server/src/workers/reportWorker.js
+++ b/collegems-server/src/workers/reportWorker.js
@@ -1,0 +1,74 @@
+import PDFDocument from "pdfkit";
+import fs from "fs";
+import path from "path";
+import { emitJobProgress, emitJobEvent } from "../queues/jobProgress.js";
+
+/**
+ * Generate a simple report PDF in the background.
+ * data: { title, lines: string[], requestedBy, fileName? }
+ */
+export async function processReportPdfJob(job, io) {
+  const data = job.data || {};
+  const requestedBy = data.requestedBy;
+  const jobId = String(job.id);
+  const title = data.title || "CollegeMS Report";
+  const lines = Array.isArray(data.lines) ? data.lines : ["No content"];
+
+  const emit = (progress, status, extra = {}) => {
+    emitJobProgress(io, {
+      queue: "ReportPDFQueue",
+      jobId,
+      name: job.name,
+      progress,
+      status,
+      requestedBy,
+      ...extra,
+    });
+  };
+
+  emit(10, "active");
+  if (typeof job.updateProgress === "function") await job.updateProgress(10);
+
+  const outDir = path.join(process.cwd(), "secure-uploads", "reports");
+  fs.mkdirSync(outDir, { recursive: true });
+  const fileName =
+    data.fileName ||
+    `report_${Date.now()}_${Math.random().toString(36).slice(2, 7)}.pdf`;
+  const filePath = path.join(outDir, fileName);
+
+  await new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 50 });
+    const stream = fs.createWriteStream(filePath);
+    doc.pipe(stream);
+
+    doc.fontSize(18).text(title, { underline: true });
+    doc.moveDown();
+    doc.fontSize(10).fillColor("#666").text(`Generated: ${new Date().toISOString()}`);
+    doc.moveDown();
+    doc.fillColor("#000").fontSize(12);
+
+    lines.forEach((line, idx) => {
+      doc.text(String(line));
+      if (idx % 20 === 0 && typeof job.updateProgress === "function") {
+        const p = Math.min(90, 10 + Math.round((idx / Math.max(lines.length, 1)) * 80));
+        job.updateProgress(p);
+        emit(p, "active");
+      }
+    });
+
+    doc.end();
+    stream.on("finish", resolve);
+    stream.on("error", reject);
+  });
+
+  if (typeof job.updateProgress === "function") await job.updateProgress(100);
+  const relative = path.join("secure-uploads", "reports", fileName).replace(/\\/g, "/");
+  emit(100, "completed", { filePath: relative });
+  emitJobEvent(io, "queue:job_completed", {
+    queue: "ReportPDFQueue",
+    jobId,
+    requestedBy,
+    result: { filePath: relative },
+  });
+  return { filePath: relative };
+}

--- a/collegems-server/src/workers/workerIo.js
+++ b/collegems-server/src/workers/workerIo.js
@@ -1,0 +1,9 @@
+let ioRef = null;
+
+export function setWorkerIo(io) {
+  ioRef = io;
+}
+
+export function getWorkerIo() {
+  return ioRef;
+}


### PR DESCRIPTION


## Description

This PR adds a Redis/BullMQ distributed background job queue in collegems-server so heavy work (bulk email, PDF reports, analytics) runs off the Express request path, with Socket.io progress and an HOD queue monitor.

## Features

- Dedicated queues: EmailQueue, ReportPDFQueue, AnalyticsQueue (BullMQ + Redis, in-memory fallback without Redis)
- Worker processors under `collegems-server/src/workers/` with retries and job progress events
- Real-time status via Socket.io (`queue:job_progress` / completed / failed)
- Admin/HOD Queue Monitor dashboard (active, failed, completed jobs)
- API: `GET /api/queues/dashboard`, enqueue endpoints for email / reports / analytics

Closes #705 