### PR TITLE
Implement Resume Text Extraction for Uploaded Resumes

### DIFF
--- a/collegems-server/src/controllers/resume.controller.js
+++ b/collegems-server/src/controllers/resume.controller.js
@@ -1,16 +1,7 @@
 // src/controllers/resume.controller.js
 import { validateResume, getFileInfo, sanitizeFilename } from '../utils/fileValidators.js';
+import { extractResumeText } from '../utils/resumeParser.js';
 import fs from 'fs';
-
-/**
- * Extract text from resume file
- * (Replace with your actual resume parsing logic)
- */
-async function extractResumeText(file) {
-  // TODO: Implement actual resume text extraction
-  // This is a placeholder - replace with your actual logic
-  return "Resume text extracted successfully";
-}
 
 /**
  * Handle Resume Analysis with Security Validation
@@ -51,10 +42,17 @@ export async function handleAnalyzeResume(req, res) {
     const safeFilename = sanitizeFilename(req.file.originalname);
 
     // Now process the validated file
-    const text = await extractResumeText(req.file);
-    
-    // Process resume text...
-    // ... your existing logic
+    let text;
+    try {
+      text = await extractResumeText(req.file);
+    } catch (parseError) {
+      const message = parseError.message || 'Failed to parse the uploaded document';
+      return res.status(422).json({
+        success: false,
+        error: message,
+        code: 'PARSE_ERROR'
+      });
+    }
 
     res.json({
       success: true,
@@ -67,7 +65,6 @@ export async function handleAnalyzeResume(req, res) {
       },
       data: {
         text: text
-        // ... rest of your data
       }
     });
 

--- a/collegems-server/src/tests/resume.controller.test.js
+++ b/collegems-server/src/tests/resume.controller.test.js
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { handleAnalyzeResume } from '../controllers/resume.controller.js';
+
+const createMockResponse = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createTempFile = (name, content) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'resume-test-'));
+  const filePath = path.join(tempDir, name);
+  fs.writeFileSync(filePath, content);
+  return { tempDir, filePath };
+};
+
+test('handleAnalyzeResume extracts text from a supported resume file', async () => {
+  const { tempDir, filePath } = createTempFile('resume.txt', 'John Doe\nSenior Software Engineer');
+  const req = {
+    file: {
+      path: filePath,
+      originalname: 'resume.txt',
+      mimetype: 'text/plain',
+      size: fs.statSync(filePath).size,
+    },
+  };
+  const res = createMockResponse();
+
+  await handleAnalyzeResume(req, res);
+
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.body.success, true);
+  assert.match(res.body.data.text, /John Doe/);
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('handleAnalyzeResume rejects missing files with a useful error', async () => {
+  const req = {};
+  const res = createMockResponse();
+
+  await handleAnalyzeResume(req, res);
+
+  assert.strictEqual(res.statusCode, 400);
+  assert.strictEqual(res.body.code, 'FILE_REQUIRED');
+  assert.match(res.body.error, /required/i);
+});
+
+test('handleAnalyzeResume rejects unsupported file types', async () => {
+  const { tempDir, filePath } = createTempFile('resume.exe', 'not a real resume');
+  const req = {
+    file: {
+      path: filePath,
+      originalname: 'resume.exe',
+      mimetype: 'application/x-msdownload',
+      size: fs.statSync(filePath).size,
+    },
+  };
+  const res = createMockResponse();
+
+  await handleAnalyzeResume(req, res);
+
+  assert.strictEqual(res.statusCode, 400);
+  assert.strictEqual(res.body.code, 'INVALID_FILE');
+  assert.match(res.body.error, /Invalid file type|unsupported/i);
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('handleAnalyzeResume rejects unreadable or invalid documents', async () => {
+  const { tempDir, filePath } = createTempFile('resume.pdf', 'not a real pdf');
+  const req = {
+    file: {
+      path: filePath,
+      originalname: 'resume.pdf',
+      mimetype: 'application/pdf',
+      size: fs.statSync(filePath).size,
+    },
+  };
+  const res = createMockResponse();
+
+  await handleAnalyzeResume(req, res);
+
+  assert.strictEqual(res.statusCode, 422);
+  assert.strictEqual(res.body.code, 'PARSE_ERROR');
+  assert.match(res.body.error, /Could not read|No text could be extracted|read/i);
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});

--- a/collegems-server/src/utils/resumeParser.js
+++ b/collegems-server/src/utils/resumeParser.js
@@ -1,0 +1,90 @@
+import fs from 'fs';
+import path from 'path';
+import mammoth from 'mammoth';
+
+let pdfParse = null;
+try {
+  pdfParse = (await import('pdf-parse')).default;
+} catch (error) {
+  pdfParse = null;
+}
+
+const MIN_EXTRACTED_TEXT_LENGTH = 20;
+
+const normalizeText = (text) => {
+  if (!text) return '';
+  return text.replace(/\s+/g, ' ').trim();
+};
+
+const getFileExtension = (file) => {
+  if (!file?.originalname && !file?.path) return '';
+  const name = file.originalname || path.basename(file.path);
+  return path.extname(name).toLowerCase();
+};
+
+export const extractResumeText = async (file) => {
+  if (!file?.path) {
+    throw new Error('Resume file is required');
+  }
+
+  if (!fs.existsSync(file.path)) {
+    throw new Error('Resume file is corrupted or unreadable');
+  }
+
+  const extension = getFileExtension(file);
+  const mimeType = (file.mimetype || '').toLowerCase();
+
+  try {
+    if (extension === '.pdf' || mimeType === 'application/pdf') {
+      if (!pdfParse) {
+        throw new Error('PDF parsing is unavailable in the current environment');
+      }
+      const buffer = fs.readFileSync(file.path);
+      const result = await pdfParse(buffer);
+      const extractedText = normalizeText(result?.text || '');
+      if (!extractedText) {
+        throw new Error('No text could be extracted from the PDF');
+      }
+      if (extractedText.length < MIN_EXTRACTED_TEXT_LENGTH) {
+        throw new Error('Could not read enough text from the PDF');
+      }
+      return extractedText;
+    }
+
+    if (extension === '.docx' || mimeType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+      const result = await mammoth.extractRawText({ path: file.path });
+      const extractedText = normalizeText(result?.value || '');
+      if (!extractedText) {
+        throw new Error('No text could be extracted from the DOCX file');
+      }
+      if (extractedText.length < MIN_EXTRACTED_TEXT_LENGTH) {
+        throw new Error('Could not read enough text from the DOCX file');
+      }
+      return extractedText;
+    }
+
+    if (extension === '.doc' || mimeType === 'application/msword') {
+      throw new Error('DOC files are not supported by the current parser');
+    }
+
+    if (extension === '.txt' || mimeType === 'text/plain') {
+      const extractedText = normalizeText(fs.readFileSync(file.path, 'utf8'));
+      if (!extractedText) {
+        throw new Error('No text could be extracted from the text file');
+      }
+      return extractedText;
+    }
+
+    throw new Error('Unsupported file type');
+  } catch (error) {
+    if (error?.message?.includes('No text could be extracted') || error?.message?.includes('Could not read enough text') || error?.message?.includes('corrupted or unreadable') || error?.message?.includes('Unsupported file type') || error?.message?.includes('current parser')) {
+      throw error;
+    }
+
+    if (extension === '.pdf' || mimeType === 'application/pdf') {
+      throw new Error('Could not read the PDF document');
+    }
+
+    throw new Error('Failed to parse the uploaded document');
+  }
+};


### PR DESCRIPTION
## Description

This PR implements real resume text extraction by replacing the existing placeholder parsing logic with support for uploaded PDF, DOCX, and TXT resumes.

The implementation uses the parsing dependencies already available in the project and keeps the existing resume-analysis workflow and response structure intact.

## Changes Made

- Replaced placeholder resume text extraction with real document parsing.
- Added a reusable `resumeParser.js` utility.
- Added support for:
  - PDF files using `pdf-parse`
  - DOCX files using `mammoth`
  - TXT files using plain text reading
- Added validation for missing and unsupported files.
- Added structured error handling for corrupted or unreadable documents.
- Preserved the existing resume analysis response format.
- Added targeted tests for the resume parsing flow.

## Error Handling

Parsing failures now return a clean response with:

- HTTP status `422`
- Error code `PARSE_ERROR`
- User-friendly error messages without exposing internal implementation details.

## Testing

Added targeted tests covering:

- ✅ Successful resume text extraction
- ✅ Missing file handling
- ✅ Unsupported file format handling
- ✅ Invalid/unreadable document handling

### Test Result

```text
4 tests passed
0 tests failed
```

## Dependencies

No new dependencies were added.

The implementation uses the existing:

- `pdf-parse`
- `mammoth`

## Scope

The changes are limited to the resume parsing workflow. No unrelated authentication, frontend, or API functionality was modified.

## Files Changed

- `resume.controller.js`
- `resumeParser.js`
- `resume.controller.test.js`

Fixes #698 